### PR TITLE
fix :  iexec apps deploy

### DIFF
--- a/src/iexec-apps.js
+++ b/src/iexec-apps.js
@@ -12,7 +12,7 @@ cli
 cli
   .command('deploy [appName]')
   .description('send app to iexec server, app binary must be located inside /apps')
-  .action(appName => apps.send(cli.network, appName).catch(() => {}));
+  .action(appName => apps.deploy(cli.network, appName).catch(() => {}));
 
 cli.parse(process.argv);
 

--- a/src/iexec-deploy.js
+++ b/src/iexec-deploy.js
@@ -9,4 +9,4 @@ cli
   .option('--chain, --network <name>', 'migrate to network name', 'ropsten')
   .parse(process.argv);
 
-migrate(cli.network).then(() => apps.send(cli.network, cli.args[0])).catch(() => {});
+migrate(cli.network).then(() => apps.deploy(cli.network, cli.args[0])).catch(() => {});


### PR DESCRIPTION

will fix it ?

  > iexec apps deploy
/usr/src/node/node-v6.11.3-linux-x64/lib/node_modules/iexec/dist/iexec-apps.js:12
cli.command('deploy [appName]').description('send app to iexec server, app binary must be located inside /apps').action(appName => apps.send(cli.network, appName).catch(() => {}));
               ^

TypeError: apps.send is not a function
    at Command.cli.command.description.action.appName (/usr/src/node/node-v6.11.3-linux-x64/lib/node_modules/iexec/dist/iexec-apps.js:12:137)