### PR TITLE
fix local host for develompent network

### DIFF
--- a/src/truffle.js
+++ b/src/truffle.js
@@ -9,7 +9,7 @@ const LOCAL_ORACLE_ADDRESS = 'local_oracle_address_value';
 module.exports = {
   networks: {
     development: {
-      host: 'http://localhost:8545',
+      host: 'localhost',
       port: 8545,
       network_id: '*', // Match any network id,
       constructorArgs: [LOCAL_ORACLE_ADDRESS],


### PR DESCRIPTION
needed to remove phrase  : 
make sure the development network host in truffle.js is well configured ('localhost' and not 'http://localhost:8545'):

here : 

https://github.com/iExecBlockchainComputing/iexec-dapp-samples/blob/timeclock/README.md