### PR TITLE
Gramine requester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
 - `iexec app check-secret` & `app.checkAppSecret(appAddress, secret)` use a TEE framework inferred from app if not specified
 - `iexec storage init` & `storage.pushStorageToken(appAddress)` use the default TEE framework if not specified
 - `iexec storage check` & `app.checkStorageTokenExists(appAddress, secret)` use the default TEE framework if not specified
+- `iexec requester check-secret <name>` & `secrets.checkRequesterSecretExists(name)` use the default TEE framework if not specified
+- `iexec requester push-secret <name>` & `secrets.pushRequesterSecret(name, value)` use the default TEE framework if not specified
 
 ## [7.2.2] 2022-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ All notable changes to this project will be documented in this file.
 
 - SMS URL resolution depends on TEE framework (default `scone`)
 - SMS URL override in `IExecConfig` or `chain.json` accepts `Record<TeeFramework,Url> | string`
-- `iexec app push-secret` & `app.pushAppSecretExists(appAddress)` use a TEE framework inferred from app if not specified
-- `iexec app check-secret` & `app.checkAppSecret(appAddress, secret)` use a TEE framework inferred from app if not specified
-- `iexec storage init` & `storage.pushStorageToken(appAddress)` use the default TEE framework if not specified
-- `iexec storage check` & `app.checkStorageTokenExists(appAddress, secret)` use the default TEE framework if not specified
-- `iexec requester check-secret <name>` & `secrets.checkRequesterSecretExists(name)` use the default TEE framework if not specified
-- `iexec requester push-secret <name>` & `secrets.pushRequesterSecret(name, value)` use the default TEE framework if not specified
+- `iexec app push-secret` and `app.pushAppSecretExists(appAddress)` use a TEE framework inferred from app if not specified
+- `iexec app check-secret` and `app.checkAppSecret(appAddress, secret)` use a TEE framework inferred from app if not specified
+- `iexec storage init` and `storage.pushStorageToken(appAddress)` use the default TEE framework if not specified
+- `iexec storage check` and `app.checkStorageTokenExists(appAddress, secret)` use the default TEE framework if not specified
+- `iexec requester check-secret <name>` and `secrets.checkRequesterSecretExists(name)` use the default TEE framework if not specified
+- `iexec requester push-secret <name>` and `secrets.pushRequesterSecret(name, value)` use the default TEE framework if not specified
+- `iexec result check-encryption-key` and `result.checkResultEncryptionKeyExists(address)` use the default TEE framework if not specified
+- `iexec result push-encryption-key` and `result.pushResultEncryptionKey(value)` use the default TEE framework if not specified
 
 ## [7.2.2] 2022-09-05
 
@@ -99,7 +101,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - ENS resolution on iExec sidechains and custom networks
-- ENS methods in CLI & lib:
+- ENS methods in CLI and lib:
   - `iexec ens resolve <name>` and `iexec.ens.resolveName(name)`
   - `iexec ens lookup <address>` and `iexec.ens.lookupAddress(address)`
   - `iexec ens get-owner <name>` and `iexec.ens.getOwner(name)`
@@ -268,15 +270,15 @@ All notable changes to this project will be documented in this file.
 - `--decrypt` option added `iexec task show <taskid> --download --decrypt` allow to decrypt downloaded result
 - `--watch` option added to `iexec deal show <dealid>` allow to watch execution status changes
 - default values for `order.createApporder()`, `order.createDatasetorder()`, `order.createWorkerpoolorder()` and `order.createRequestorder()`.
-- support for units in `parseEth()` & `parseRLC()` methods
+- support for units in `parseEth()` and `parseRLC()` methods
 
 ### Changed
 
-- [BREAKING] `iexec app show <index>` & `app.showUserApp(index)` first index is `0` previously was `1`
-- [BREAKING] `iexec dataset show <index>` & `dataset.showUserDataset(index)` first index is `0` previously was `1`
-- [BREAKING] `iexec workerpool show <index>` & `dataset.showUserWorkerpool(index)` first index is `0` previously was `1`
+- [BREAKING] `iexec app show <index>` and `app.showUserApp(index)` first index is `0` previously was `1`
+- [BREAKING] `iexec dataset show <index>` and `dataset.showUserDataset(index)` first index is `0` previously was `1`
+- [BREAKING] `iexec workerpool show <index>` and `dataset.showUserWorkerpool(index)` first index is `0` previously was `1`
 - [BREAKING] `iexec dataset check-secret` returned json key is now `isSecretSet` previously was `isKnownAddress`
-- [BREAKING] `iexec task show` & `task.show(taskid)` returned `task.results` is an object previously was url or hexString
+- [BREAKING] `iexec task show` and `task.show(taskid)` returned `task.results` is an object previously was url or hexString
 - [BREAKING] `iexec app run` option `--dataset <address|"deployed">` using last deployed dataset is no more implicit
 - [BREAKING] `iexec app run` option `--workerpool <address|"deployed">` using last deployed workerpool is no more implicit
 - [BREAKING] `bridge.bridgedChainId` is now used to override bridged chain chainId in `iexec.json` previously `bridge.bridgedNetworkId` was used
@@ -287,7 +289,7 @@ All notable changes to this project will be documented in this file.
 - access to the blockchain through ethers default provider
 - standardized CLI messages format
 - fixed mutation in order sign methods
-- fixed `iexec wallet sweep` & `wallet.sweep()`
+- fixed `iexec wallet sweep` and `wallet.sweep()`
 - fixed method name `iexec.order.publishWorkerpoolorder()`
 - fixed method name `iexec.order.unpublishWorkerpoolorder()`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 - SMS URL override in `IExecConfig` or `chain.json` accepts `Record<TeeFramework,Url> | string`
 - `iexec app push-secret` & `app.pushAppSecretExists(appAddress)` use a TEE framework inferred from app if not specified
 - `iexec app check-secret` & `app.checkAppSecret(appAddress, secret)` use a TEE framework inferred from app if not specified
+- `iexec storage init` & `storage.pushStorageToken(appAddress)` use the default TEE framework if not specified
+- `iexec storage check` & `app.checkStorageTokenExists(appAddress, secret)` use the default TEE framework if not specified
 
 ## [7.2.2] 2022-09-05
 

--- a/docs/classes/IExecResultModule.md
+++ b/docs/classes/IExecResultModule.md
@@ -61,7 +61,7 @@ current IExecConfig
 
 ### checkResultEncryptionKeyExists
 
-▸ **checkResultEncryptionKeyExists**(`beneficiaryAddress`): `Promise`<`boolean`\>
+▸ **checkResultEncryptionKeyExists**(`beneficiaryAddress`, `options`): `Promise`<`boolean`\>
 
 check if a beneficiary result encryption key exists in the Secret Management Service
 
@@ -76,6 +76,8 @@ console.log('encryption key available:', isEncryptionKeyAvailable);
 | Name | Type |
 | :------ | :------ |
 | `beneficiaryAddress` | `string` |
+| `options` | `Object` |
+| `options.teeFramework?` | [`TeeFramework`](../modules/internal_.md#teeframework) |
 
 #### Returns
 
@@ -121,6 +123,7 @@ console.log('encryption key pushed:', isPushed);
 | `rsaPublicKey` | `string` |
 | `options?` | `Object` |
 | `options.forceUpdate?` | `boolean` |
+| `options.teeFramework?` | [`TeeFramework`](../modules/internal_.md#teeframework) |
 
 #### Returns
 

--- a/docs/classes/IExecSecretsModule.md
+++ b/docs/classes/IExecSecretsModule.md
@@ -61,7 +61,7 @@ current IExecConfig
 
 ### checkRequesterSecretExists
 
-▸ **checkRequesterSecretExists**(`requesterAddress`, `secretName`): `Promise`<`boolean`\>
+▸ **checkRequesterSecretExists**(`requesterAddress`, `secretName`, `options?`): `Promise`<`boolean`\>
 
 check if a named secret exists for the requester in the Secret Management Service
 
@@ -77,6 +77,8 @@ console.log('secret "my-password" set:', isSecretSet);
 | :------ | :------ |
 | `requesterAddress` | `string` |
 | `secretName` | `String` |
+| `options?` | `Object` |
+| `options.teeFramework?` | [`TeeFramework`](../modules/internal_.md#teeframework) |
 
 #### Returns
 
@@ -86,7 +88,7 @@ ___
 
 ### pushRequesterSecret
 
-▸ **pushRequesterSecret**(`secretName`, `secretValue`): `Promise`<{ `isPushed`: `boolean`  }\>
+▸ **pushRequesterSecret**(`secretName`, `secretValue`, `options?`): `Promise`<{ `isPushed`: `boolean`  }\>
 
 **SIGNER REQUIRED, ONLY REQUESTER**
 
@@ -108,6 +110,8 @@ console.log('pushed secret "my-password":', isPushed);
 | :------ | :------ |
 | `secretName` | `String` |
 | `secretValue` | `String` |
+| `options?` | `Object` |
+| `options.teeFramework?` | [`TeeFramework`](../modules/internal_.md#teeframework) |
 
 #### Returns
 

--- a/docs/classes/IExecStorageModule.md
+++ b/docs/classes/IExecStorageModule.md
@@ -81,6 +81,7 @@ console.log('IPFS storage initialized:', isIpfsStorageInitialized);
 | `beneficiaryAddress` | `string` |
 | `options?` | `Object` |
 | `options.provider?` | `string` |
+| `options.teeFramework?` | [`TeeFramework`](../modules/internal_.md#teeframework) |
 
 #### Returns
 
@@ -142,6 +143,7 @@ console.log('dropbox storage initialized:', isPushed);
 | `options?` | `Object` |
 | `options.forceUpdate?` | `boolean` |
 | `options.provider?` | `string` |
+| `options.teeFramework?` | [`TeeFramework`](../modules/internal_.md#teeframework) |
 
 #### Returns
 

--- a/src/cli/cmd/iexec-requester.js
+++ b/src/cli/cmd/iexec-requester.js
@@ -16,6 +16,7 @@ const {
   prompt,
   Spinner,
   getSmsUrlFromChain,
+  optionCreator,
 } = require('../utils/cli-helper');
 const { loadChain, connectKeystore } = require('../utils/chains');
 const { Keystore } = require('../utils/keystore');
@@ -30,6 +31,7 @@ addWalletLoadOptions(pushSecret);
 pushSecret
   .option(...option.chain())
   .option(...option.secretValue())
+  .addOption(optionCreator.teeFramework())
   .description(desc.pushRequesterSecret())
   .action(async (secretName, opts) => {
     await checkUpdate(opts);
@@ -45,8 +47,9 @@ pushSecret
       ]);
       await connectKeystore(chain, keystore);
       const { contracts } = chain;
-      const sms = getSmsUrlFromChain(chain);
-
+      const sms = getSmsUrlFromChain(chain, {
+        teeFramework: opts.teeFramework,
+      });
       spinner.info(`Secret "${secretName}" for address ${address}`);
       const secretValue =
         opts.secretValue ||
@@ -77,6 +80,7 @@ addGlobalOptions(checkSecret);
 addWalletLoadOptions(checkSecret);
 checkSecret
   .option(...option.chain())
+  .addOption(optionCreator.teeFramework())
   .description(desc.checkSecret())
   .action(async (secretName, requesterAddress, opts) => {
     await checkUpdate(opts);
@@ -99,7 +103,9 @@ checkSecret
         );
       }
       const { contracts } = chain;
-      const sms = getSmsUrlFromChain(chain);
+      const sms = getSmsUrlFromChain(chain, {
+        teeFramework: opts.teeFramework,
+      });
       const secretExists = await checkRequesterSecretExists(
         contracts,
         sms,

--- a/src/cli/cmd/iexec-result.js
+++ b/src/cli/cmd/iexec-result.js
@@ -30,6 +30,7 @@ const {
   publicKeyName,
   privateKeyName,
   getSmsUrlFromChain,
+  optionCreator,
 } = require('../utils/cli-helper');
 const { loadChain, connectKeystore } = require('../utils/chains');
 const { saveTextToFile } = require('../utils/fs');
@@ -207,6 +208,7 @@ pushSecret
   .option(...option.chain())
   .option(...option.forceUpdateSecret())
   .option(...option.secretPath())
+  .addOption(optionCreator.teeFramework())
   .description(desc.pushResultKey())
   .action(async (opts) => {
     await checkUpdate(opts);
@@ -222,10 +224,9 @@ pushSecret
       ]);
       await connectKeystore(chain, keystore);
       const { contracts } = chain;
-      const sms = getSmsUrlFromChain(chain);
-
-      debug('address', address);
-
+      const sms = getSmsUrlFromChain(chain, {
+        teeFramework: opts.teeFramework,
+      });
       let secretFilePath;
       if (opts.secretPath) {
         secretFilePath = opts.secretPath;
@@ -238,7 +239,6 @@ pushSecret
       }
       const publicKey = await fs.readFile(secretFilePath, 'utf8');
       const secretToPush = Buffer.from(publicKey, 'utf8').toString('base64');
-      debug('secretToPush', secretToPush);
       const { isPushed, isUpdated } = await pushWeb2Secret(
         contracts,
         sms,
@@ -265,6 +265,7 @@ addGlobalOptions(checkSecret);
 addWalletLoadOptions(checkSecret);
 checkSecret
   .option(...option.chain())
+  .addOption(optionCreator.teeFramework())
   .description(desc.checkSecret())
   .action(async (address, opts) => {
     await checkUpdate(opts);
@@ -285,7 +286,9 @@ checkSecret
         spinner.info(`Checking encryption key exists for wallet ${keyAddress}`);
       }
       const { contracts } = chain;
-      const sms = getSmsUrlFromChain(chain);
+      const sms = getSmsUrlFromChain(chain, {
+        teeFramework: opts.teeFramework,
+      });
       const secretExists = await checkWeb2SecretExists(
         contracts,
         sms,

--- a/src/cli/cmd/iexec-storage.js
+++ b/src/cli/cmd/iexec-storage.js
@@ -20,6 +20,7 @@ const {
   Spinner,
   getPropertyFormChain,
   getSmsUrlFromChain,
+  optionCreator,
 } = require('../utils/cli-helper');
 const { loadChain, connectKeystore } = require('../utils/chains');
 const { Keystore } = require('../utils/keystore');
@@ -33,6 +34,7 @@ initStorage
   .option(...option.chain())
   .option(...option.forceUpdateSecret())
   .option(...option.storageToken())
+  .addOption(optionCreator.teeFramework())
   .description(desc.initStorage())
   .action(async (provider, opts) => {
     await checkUpdate(opts);
@@ -45,7 +47,9 @@ initStorage
         keystore.accounts(),
       ]);
       const { contracts } = chain;
-      const smsURL = getSmsUrlFromChain(chain);
+      const smsURL = getSmsUrlFromChain(chain, {
+        teeFramework: opts.teeFramework,
+      });
       const resultProxyURL = getPropertyFormChain(chain, 'resultProxy');
 
       const providerName = provider || 'default';
@@ -105,6 +109,7 @@ addWalletLoadOptions(checkStorage);
 checkStorage
   .option(...option.chain())
   .option(...option.user())
+  .addOption(optionCreator.teeFramework())
   .description(desc.checkStorage())
   .action(async (provider, opts) => {
     await checkUpdate(opts);
@@ -117,7 +122,9 @@ checkStorage
         keystore.accounts(),
       ]);
       const { contracts } = chain;
-      const smsURL = getSmsUrlFromChain(chain);
+      const smsURL = getSmsUrlFromChain(chain, {
+        teeFramework: opts.teeFramework,
+      });
       const providerName = provider || 'default';
       const tokenKeyName = getStorageTokenKeyName(providerName);
       const userAddress = opts.user || address;

--- a/src/lib/IExecResultModule.d.ts
+++ b/src/lib/IExecResultModule.d.ts
@@ -1,6 +1,6 @@
 import IExecConfig from './IExecConfig';
 import IExecModule from './IExecModule';
-import { Addressish } from './types';
+import { Addressish, TeeFramework } from './types';
 
 /**
  * module exposing result methods
@@ -17,6 +17,7 @@ export default class IExecResultModule extends IExecModule {
    */
   checkResultEncryptionKeyExists(
     beneficiaryAddress: Addressish,
+    options: { teeFramework?: TeeFramework },
   ): Promise<boolean>;
   /**
    * **SIGNER REQUIRED, ONLY BENEFICIARY**
@@ -50,6 +51,7 @@ export default class IExecResultModule extends IExecModule {
     rsaPublicKey: string,
     options?: {
       forceUpdate?: boolean;
+      teeFramework?: TeeFramework;
     },
   ): Promise<{ isPushed: boolean; isUpdated: boolean }>;
   /**

--- a/src/lib/IExecResultModule.js
+++ b/src/lib/IExecResultModule.js
@@ -7,20 +7,23 @@ class IExecResultModule extends IExecModule {
   constructor(...args) {
     super(...args);
 
-    this.checkResultEncryptionKeyExists = async (address) =>
+    this.checkResultEncryptionKeyExists = async (
+      address,
+      { teeFramework } = {},
+    ) =>
       checkWeb2SecretExists(
         await this.config.resolveContractsClient(),
-        await this.config.resolveSmsURL(),
+        await this.config.resolveSmsURL({ teeFramework }),
         address,
         getResultEncryptionKeyName(),
       );
     this.pushResultEncryptionKey = async (
       publicKey,
-      { forceUpdate = false } = {},
+      { forceUpdate = false, teeFramework } = {},
     ) =>
       pushWeb2Secret(
         await this.config.resolveContractsClient(),
-        await this.config.resolveSmsURL(),
+        await this.config.resolveSmsURL({ teeFramework }),
         getResultEncryptionKeyName(),
         publicKey,
         { forceUpdate },

--- a/src/lib/IExecSecretsModule.d.ts
+++ b/src/lib/IExecSecretsModule.d.ts
@@ -1,6 +1,6 @@
 import IExecConfig from './IExecConfig';
 import IExecModule from './IExecModule';
-import { Addressish } from './types';
+import { Addressish, TeeFramework } from './types';
 
 /**
  * module exposing secrets methods
@@ -18,6 +18,9 @@ export default class IExecSecretsModule extends IExecModule {
   checkRequesterSecretExists(
     requesterAddress: Addressish,
     secretName: String,
+    options?: {
+      teeFramework?: TeeFramework;
+    },
   ): Promise<boolean>;
   /**
    * **SIGNER REQUIRED, ONLY REQUESTER**
@@ -37,6 +40,9 @@ export default class IExecSecretsModule extends IExecModule {
   pushRequesterSecret(
     secretName: String,
     secretValue: String,
+    options?: {
+      teeFramework?: TeeFramework;
+    },
   ): Promise<{ isPushed: boolean }>;
   /**
    * Create an IExecSecretsModule instance using an IExecConfig instance

--- a/src/lib/IExecSecretsModule.js
+++ b/src/lib/IExecSecretsModule.js
@@ -6,17 +6,25 @@ class IExecSecretModule extends IExecModule {
   constructor(...args) {
     super(...args);
 
-    this.checkRequesterSecretExists = async (address, secretName) =>
+    this.checkRequesterSecretExists = async (
+      address,
+      secretName,
+      { teeFramework } = {},
+    ) =>
       checkRequesterSecretExists(
         await this.config.resolveContractsClient(),
-        await this.config.resolveSmsURL(),
+        await this.config.resolveSmsURL({ teeFramework }),
         address,
         secretName,
       );
-    this.pushRequesterSecret = async (secretName, secretValue) =>
+    this.pushRequesterSecret = async (
+      secretName,
+      secretValue,
+      { teeFramework } = {},
+    ) =>
       pushRequesterSecret(
         await this.config.resolveContractsClient(),
-        await this.config.resolveSmsURL(),
+        await this.config.resolveSmsURL({ teeFramework }),
         secretName,
         secretValue,
       );

--- a/src/lib/IExecStorageModule.d.ts
+++ b/src/lib/IExecStorageModule.d.ts
@@ -1,6 +1,6 @@
 import IExecConfig from './IExecConfig';
 import IExecModule from './IExecModule';
-import { Addressish } from './types';
+import { Addressish, TeeFramework } from './types';
 
 /**
  * module exposing storage methods
@@ -21,6 +21,7 @@ export default class IExecStorageModule extends IExecModule {
     beneficiaryAddress: Addressish,
     options?: {
       provider?: string;
+      teeFramework?: TeeFramework;
     },
   ): Promise<boolean>;
   /**
@@ -62,6 +63,7 @@ export default class IExecStorageModule extends IExecModule {
     token: string,
     options?: {
       provider?: string;
+      teeFramework?: TeeFramework;
       forceUpdate?: boolean;
     },
   ): Promise<{ isPushed: boolean; isUpdated: boolean }>;

--- a/src/lib/IExecStorageModule.js
+++ b/src/lib/IExecStorageModule.js
@@ -13,20 +13,24 @@ class IExecStorageModule extends IExecModule {
         await this.config.resolveContractsClient(),
         await this.config.resolveResultProxyURL(),
       );
-    this.checkStorageTokenExists = async (address, { provider } = {}) =>
+    this.checkStorageTokenExists = async (
+      address,
+      { provider, teeFramework } = {},
+    ) =>
       checkWeb2SecretExists(
         await this.config.resolveContractsClient(),
-        await this.config.resolveSmsURL(),
+        await this.config.resolveSmsURL({ teeFramework }),
         address,
         getStorageTokenKeyName(provider),
       );
+
     this.pushStorageToken = async (
       token,
-      { provider, forceUpdate = false } = {},
+      { provider, teeFramework, forceUpdate = false } = {},
     ) =>
       pushWeb2Secret(
         await this.config.resolveContractsClient(),
-        await this.config.resolveSmsURL(),
+        await this.config.resolveSmsURL({ teeFramework }),
         getStorageTokenKeyName(provider),
         token,
         { forceUpdate },

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -132,6 +132,19 @@ const setPoorWallet1 = () =>
     'wallet.json',
   );
 
+const setWallet = async (privateKey) => {
+  const wallet = privateKey
+    ? new ethers.Wallet(privateKey)
+    : ethers.Wallet.createRandom();
+  const jsonWallet = {
+    privateKey: wallet.privateKey,
+    publicKey: wallet.publicKey,
+    address: wallet.address,
+  };
+  await saveJSONToFile(jsonWallet, 'wallet.json');
+  return jsonWallet;
+};
+
 const setTokenChain = (options) =>
   saveJSONToFile(
     {
@@ -2349,6 +2362,98 @@ describe('[Mainchain]', () => {
     ).catch((e) => e.message);
     const resErr = JSON.parse(rawErr);
     expect(resErr.ok).toBe(false);
+  });
+
+  // REQUESTER
+  test('[common] requester secret', async () => {
+    await setTokenChainOpenethereum();
+    const { privateKey, address } = await setWallet();
+    // check own
+    const checkOwnNotPushed = JSON.parse(
+      await execAsync(`${iexecPath} requester check-secret foo --raw`),
+    );
+    expect(checkOwnNotPushed.ok).toBe(true);
+    expect(checkOwnNotPushed.name).toBe('foo');
+    expect(checkOwnNotPushed.isSet).toBe(false);
+
+    // push
+    const push = JSON.parse(
+      await execAsync(
+        `${iexecPath} requester push-secret foo --secret-value FOO --raw`,
+      ),
+    );
+    expect(push.ok).toBe(true);
+    expect(push.name).toBe('foo');
+    expect(push.isPushed).toBe(true);
+    // cannot update requester secret
+    const pushUpdate = JSON.parse(
+      await execAsync(
+        `${iexecPath} requester push-secret foo --secret-value FOOD --raw`,
+      ).catch((err) => err.message),
+    );
+    expect(pushUpdate.ok).toBe(false);
+
+    // check own pushed
+    const checkOwnPushed = JSON.parse(
+      await execAsync(`${iexecPath} requester check-secret foo --raw`),
+    );
+    expect(checkOwnPushed.ok).toBe(true);
+    expect(checkOwnPushed.name).toBe('foo');
+    expect(checkOwnPushed.isSet).toBe(true);
+
+    // anyone can check-secret
+    await removeWallet();
+    const checkPushed = JSON.parse(
+      await execAsync(
+        `${iexecPath} requester check-secret foo ${address} --raw`,
+      ),
+    );
+    expect(checkPushed.ok).toBe(true);
+    expect(checkPushed.name).toBe('foo');
+    expect(checkPushed.isSet).toBe(true);
+
+    const checkNotPushed = JSON.parse(
+      await execAsync(
+        `${iexecPath} requester check-secret FOO ${address} --raw`,
+      ),
+    );
+    expect(checkNotPushed.ok).toBe(true);
+    expect(checkNotPushed.name).toBe('FOO');
+    expect(checkNotPushed.isSet).toBe(false);
+
+    // check secret TEE framework validation
+    await expect(
+      execAsync(
+        `${iexecPath} requester check-secret foo ${address} --tee-framework tee --raw`,
+      ),
+    ).rejects.toThrow();
+
+    // check secret TEE framework override
+    const checkOtherFramework = JSON.parse(
+      await execAsync(
+        `${iexecPath} requester check-secret foo ${address} --tee-framework ${TEE_FRAMEWORKS.GRAMINE} --raw`,
+      ),
+    );
+    expect(checkOtherFramework.ok).toBe(true);
+    expect(checkOtherFramework.name).toBe('foo');
+    expect(checkOtherFramework.isSet).toBe(false);
+
+    // push secret TEE framework override
+    await setWallet(privateKey);
+    const pushOtherFramework = JSON.parse(
+      await execAsync(
+        `${iexecPath} requester push-secret foo --secret-value foo --tee-framework ${TEE_FRAMEWORKS.GRAMINE} --raw`,
+      ),
+    );
+    expect(pushOtherFramework.ok).toBe(true);
+    const checkOtherFrameworkPushed = JSON.parse(
+      await execAsync(
+        `${iexecPath} requester check-secret foo ${address} --tee-framework ${TEE_FRAMEWORKS.GRAMINE} --raw`,
+      ),
+    );
+    expect(checkOtherFrameworkPushed.ok).toBe(true);
+    expect(checkOtherFrameworkPushed.name).toBe('foo');
+    expect(checkOtherFrameworkPushed.isSet).toBe(true);
   });
 });
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -4004,6 +4004,13 @@ describe('[Common]', () => {
       expect(resAlreadyExists.error.message).toBe(
         'default storage is already initialized, use --force-update option to update your storage token',
       );
+      const rawInitWithTeeFramework = await execAsync(
+        `${iexecPath} storage init --tee-framework gramine --raw`,
+      );
+      const resInitWithTeeFramework = JSON.parse(rawInitWithTeeFramework);
+      expect(resInitWithTeeFramework.ok).toBe(true);
+      expect(resInitWithTeeFramework.isInitialized).toBe(true);
+      expect(resInitWithTeeFramework.isUpdated).toBe(false);
     });
 
     test('iexec storage init --force-update', async () => {
@@ -4070,6 +4077,12 @@ describe('[Common]', () => {
       const resAlreadyExists = JSON.parse(rawAlreadyExists);
       expect(resAlreadyExists.ok).toBe(true);
       expect(resAlreadyExists.isInitialized).toBe(true);
+      const rawWithTeeFramework = await execAsync(
+        `${iexecPath} storage check --tee-framework gramine --raw`,
+      );
+      const resWithTeeFramework = JSON.parse(rawWithTeeFramework);
+      expect(resWithTeeFramework.ok).toBe(true);
+      expect(resWithTeeFramework.isInitialized).toBe(false);
     });
 
     test('iexec storage check --user', async () => {

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -8031,6 +8031,11 @@ describe('[storage]', () => {
         `Secret "iexec-result-iexec-ipfs-token" already exists for ${randomWallet.address}`,
       ),
     );
+    const pushForTeeFramework = await iexec.storage.pushStorageToken('oops', {
+      teeFramework: 'gramine',
+    });
+    expect(pushForTeeFramework.isPushed).toBe(true);
+    expect(pushForTeeFramework.isUpdated).toBe(false);
   });
 
   test('storage.pushStorageToken() (provider: "default")', async () => {
@@ -8153,6 +8158,17 @@ describe('[storage]', () => {
         provider: 'test',
       }),
     ).rejects.toThrow(Error('"test" not supported'));
+    const unsetForTeeFramework = await iexec.storage.checkStorageTokenExists(
+      randomWallet.address,
+      { teeFramework: 'gramine' },
+    );
+    expect(unsetForTeeFramework).toBe(false);
+    await iexec.storage.pushStorageToken('oops', { teeFramework: 'gramine' });
+    const setForTeeFramework = await iexec.storage.checkStorageTokenExists(
+      randomWallet.address,
+      { teeFramework: 'gramine' },
+    );
+    expect(setForTeeFramework).toBe(true);
   });
 });
 

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -8196,6 +8196,21 @@ describe('[result]', () => {
         `Secret "iexec-result-encryption-public-key" already exists for ${randomWallet.address}`,
       ),
     );
+    await expect(
+      iexec.result.pushResultEncryptionKey('oops', {
+        teeFramework: TEE_FRAMEWORKS.SCONE,
+      }),
+    ).rejects.toThrow(
+      Error(
+        `Secret "iexec-result-encryption-public-key" already exists for ${randomWallet.address}`,
+      ),
+    );
+    const pushForTeeFrameworkRes = await iexec.result.pushResultEncryptionKey(
+      'oops',
+      { teeFramework: TEE_FRAMEWORKS.GRAMINE },
+    );
+    expect(pushForTeeFrameworkRes.isPushed).toBe(true);
+    expect(pushForTeeFrameworkRes.isUpdated).toBe(false);
   });
 
   test('result.pushResultEncryptionKey() (forceUpdate)', async () => {
@@ -8249,6 +8264,16 @@ describe('[result]', () => {
       randomWallet.address,
     );
     expect(withSecretRes).toBe(true);
+    const withSecretForTeeFrameworkRes =
+      await iexec.result.checkResultEncryptionKeyExists(randomWallet.address, {
+        teeFramework: TEE_FRAMEWORKS.SCONE,
+      });
+    expect(withSecretForTeeFrameworkRes).toBe(true);
+    const withoutSecretForTeeFrameworkRes =
+      await iexec.result.checkResultEncryptionKeyExists(randomWallet.address, {
+        teeFramework: TEE_FRAMEWORKS.GRAMINE,
+      });
+    expect(withoutSecretForTeeFrameworkRes).toBe(false);
   });
 
   test('result.decryptResult()', async () => {

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -8348,6 +8348,12 @@ describe('[secrets]', () => {
     ).rejects.toThrow(
       Error(`Secret "foo" already exists for ${randomWallet.address}`),
     );
+    const pushForTeeFrameworkRes = await iexec.secrets.pushRequesterSecret(
+      'foo',
+      'oops',
+      { teeFramework: TEE_FRAMEWORKS.GRAMINE },
+    );
+    expect(pushForTeeFrameworkRes.isPushed).toBe(true);
   });
 
   test('result.checkRequesterSecretExists()', async () => {
@@ -8372,6 +8378,11 @@ describe('[secrets]', () => {
     await expect(
       iexec.secrets.checkRequesterSecretExists(randomWallet.address, 'foo'),
     ).resolves.toBe(true);
+    await expect(
+      iexec.secrets.checkRequesterSecretExists(randomWallet.address, 'foo', {
+        teeFramework: TEE_FRAMEWORKS.GRAMINE,
+      }),
+    ).resolves.toBe(false);
   });
 });
 


### PR DESCRIPTION
- `iexec storage init` and `storage.pushStorageToken(appAddress)` use the default TEE framework if not specified
- `iexec storage check` and `app.checkStorageTokenExists(appAddress, secret)` use the default TEE framework if not specified
- `iexec requester check-secret <name>` and `secrets.checkRequesterSecretExists(name)` use the default TEE framework if not specified
- `iexec requester push-secret <name>` and `secrets.pushRequesterSecret(name, value)` use the default TEE framework if not specified
- `iexec result check-encryption-key` and `result.checkResultEncryptionKeyExists(address)` use the default TEE framework if not specified
- `iexec result push-encryption-key` and `result.pushResultEncryptionKey(value)` use the default TEE framework if not specified