### PR TITLE
Fix minor issue with CLI.md automatic doc generation

### DIFF
--- a/generateCliDoc.cjs
+++ b/generateCliDoc.cjs
@@ -77,7 +77,7 @@ const jsonDocToMd = (jsonDoc) => {
   const getCommandsList = (commandsArray) =>
     `${commandsArray
       .map(
-        ({ name, fullName }) => `- ${getMdInternalLink(name, fullName)}${EOL}`,
+        ({ fullName }) => `- ${getMdInternalLink(fullName, fullName)}${EOL}`,
       )
       .join('')}${EOL}`;
 

--- a/src/cli/utils/cli-helper.js
+++ b/src/cli/utils/cli-helper.js
@@ -19,7 +19,7 @@ import packageJSON, { version } from '../../common/generated/sdk/package.js';
 
 const debug = Debug('help');
 
-export const finalizeCli = (cli) => {
+export const finalizeCli = async (cli) => {
   if (process.env.GENERATE_DOC) {
     const processOptions = (options) =>
       options.map((o) => ({
@@ -49,6 +49,15 @@ export const finalizeCli = (cli) => {
         })),
       }),
     );
+
+    // When dynamically generating the CLI doc using the 'GENERATE_DOC' env var,
+    // calling process.exit(0) immediately after a console.log(...) 
+    // may randomly truncate the output string, mainly because console.log()
+    // internal buffer is not fully flushed. This issue usually occurs with
+    // commands offering large number of subcommands. To quickly fix the problem
+    // simply add a small sleep before exiting.
+    await new Promise(resolve => { setTimeout(resolve, 500); });
+
     process.exit(0);
   }
 


### PR DESCRIPTION
- Sometimes (randomly) the CLI.md Command paragraph is not correct. After a bit of inquiry, I finally realised that the `console.log(JSON.stringify(...))` call in `finalizeCli` was incomplete, the output string was truncated thus resulting in a later JSON parse error. This was mainly due to console.log not having enough time to flush before `process.exit(0)`

- Little improvement, fix `init` and `info` entries. 

Hope it helps!