### PR TITLE
Fix wrong func name: 'info.missingAddress'

### DIFF
--- a/src/cli/cmd/iexec-app.js
+++ b/src/cli/cmd/iexec-app.js
@@ -242,7 +242,7 @@ show
       if (!isAddress && !userAddress)
         throw Error(`Missing option ${option.user()[0]} or wallet`);
 
-      if (!addressOrIndex) throw Error(info.missingAddress(objName));
+      if (!addressOrIndex) throw Error(info.missingAddressOrDeployed(objName, chain.id));
       spinner.start(info.showing(objName));
 
       let res;

--- a/src/cli/cmd/iexec-dataset.js
+++ b/src/cli/cmd/iexec-dataset.js
@@ -191,7 +191,7 @@ show
       if (!isAddress && !userAddress)
         throw Error(`Missing option ${option.user()[0]} or wallet`);
 
-      if (!addressOrIndex) throw Error(info.missingAddress(objName));
+      if (!addressOrIndex) throw Error(info.missingAddressOrDeployed(objName, chain.id));
 
       spinner.start(info.showing(objName));
 


### PR DESCRIPTION
Hi Pierre!, just fixed this little typo. I came around a curious error message when, by accident, I forgot to specify an address or an index in the following cli command call: `iexec app show`

- replace unknown function call `info.missingAddress(...)`
- by more recent function call `info.missingAddressOrDeployed(...)`

