### PR TITLE
Release/8.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [8.2.1] 2023-08-01
+
+### Changed
+
+- fix missing import causing `decryptResult()` to crash in browser
+
 ## [8.2.0] 2023-07-28
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iexec",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iexec",
-      "version": "8.2.0",
+      "version": "8.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ensdomains/ens-contracts": "^0.0.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iexec",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "description": "iExec SDK",
   "bin": {
     "iexec": "./dist/esm/cli/cmd/iexec.js"

--- a/src/common/generated/sdk/package.js
+++ b/src/common/generated/sdk/package.js
@@ -1,6 +1,6 @@
 // this file is auto generated do not edit it
 /* eslint-disable */
 export const name = "iexec";
-export const version = "8.2.0";
+export const version = "8.2.1";
 export const description = "iExec SDK";
 export default { name, version, description };

--- a/src/common/utils/result-utils.js
+++ b/src/common/utils/result-utils.js
@@ -1,4 +1,5 @@
 import Debug from 'debug';
+import { Buffer } from 'buffer';
 import JSZip from 'jszip';
 import forgeAes from '../libs/forge-aes.js';
 import forgePki from '../libs/forge-pki.js';


### PR DESCRIPTION
## [8.2.1] 2023-08-01

### Changed

- fix missing import causing `decryptResult()` to crash in browser