### PR TITLE
fix provider popup on new IExec

### DIFF
--- a/docs/classes/BrowserProviderSigner.md
+++ b/docs/classes/BrowserProviderSigner.md
@@ -1,0 +1,140 @@
+[iexec](../README.md) / [Exports](../modules.md) / BrowserProviderSigner
+
+# Class: BrowserProviderSigner
+
+## Hierarchy
+
+- `AbstractSigner`
+
+  ↳ **`BrowserProviderSigner`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](BrowserProviderSigner.md#constructor)
+
+### Methods
+
+- [connect](BrowserProviderSigner.md#connect)
+- [getAddress](BrowserProviderSigner.md#getaddress)
+- [signMessage](BrowserProviderSigner.md#signmessage)
+- [signTransaction](BrowserProviderSigner.md#signtransaction)
+- [signTypedData](BrowserProviderSigner.md#signtypeddata)
+
+## Constructors
+
+### constructor
+
+• **new BrowserProviderSigner**(`ethereum`, `network?`): [`BrowserProviderSigner`](BrowserProviderSigner.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `ethereum` | `Eip1193Provider` |
+| `network?` | `Networkish` |
+
+#### Returns
+
+[`BrowserProviderSigner`](BrowserProviderSigner.md)
+
+#### Overrides
+
+AbstractSigner.constructor
+
+## Methods
+
+### connect
+
+▸ **connect**(`provider`): `Signer`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `provider` | `Provider` |
+
+#### Returns
+
+`Signer`
+
+#### Overrides
+
+AbstractSigner.connect
+
+___
+
+### getAddress
+
+▸ **getAddress**(): `Promise`<`string`\>
+
+#### Returns
+
+`Promise`<`string`\>
+
+#### Overrides
+
+AbstractSigner.getAddress
+
+___
+
+### signMessage
+
+▸ **signMessage**(`message`): `Promise`<`string`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | `string` \| `Uint8Array` |
+
+#### Returns
+
+`Promise`<`string`\>
+
+#### Overrides
+
+AbstractSigner.signMessage
+
+___
+
+### signTransaction
+
+▸ **signTransaction**(`tx`): `Promise`<`string`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `tx` | `TransactionRequest` |
+
+#### Returns
+
+`Promise`<`string`\>
+
+#### Overrides
+
+AbstractSigner.signTransaction
+
+___
+
+### signTypedData
+
+▸ **signTypedData**(`domain`, `types`, `value`): `Promise`<`string`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `domain` | `TypedDataDomain` |
+| `types` | `Record`<`string`, `TypedDataField`[]\> |
+| `value` | `Record`<`string`, `any`\> |
+
+#### Returns
+
+`Promise`<`string`\>
+
+#### Overrides
+
+AbstractSigner.signTypedData

--- a/docs/classes/EnhancedWallet.md
+++ b/docs/classes/EnhancedWallet.md
@@ -14,10 +14,6 @@
 
 - [constructor](EnhancedWallet.md#constructor)
 
-### Methods
-
-- [signTypedData](EnhancedWallet.md#signtypeddata)
-
 ## Constructors
 
 ### constructor
@@ -41,25 +37,3 @@
 #### Overrides
 
 Wallet.constructor
-
-## Methods
-
-### signTypedData
-
-▸ **signTypedData**(`domain`, `types`, `value`): `Promise`<`string`\>
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `domain` | `TypedDataDomain` |
-| `types` | `Record`<`string`, `TypedDataField`[]\> |
-| `value` | `Record`<`string`, `any`\> |
-
-#### Returns
-
-`Promise`<`string`\>
-
-#### Overrides
-
-Wallet.signTypedData

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -15,6 +15,7 @@
 
 ### Classes
 
+- [BrowserProviderSigner](classes/BrowserProviderSigner.md)
 - [EnhancedWallet](classes/EnhancedWallet.md)
 - [IExec](classes/IExec.md)
 - [IExecAccountModule](classes/IExecAccountModule.md)

--- a/src/common/utils/signers.d.ts
+++ b/src/common/utils/signers.d.ts
@@ -1,6 +1,16 @@
-
-import { Wallet, BlockTag, TypedDataDomain, TypedDataField, SigningKey, Provider } from 'ethers';
-
+import {
+  Wallet,
+  BlockTag,
+  SigningKey,
+  Provider,
+  AbstractSigner,
+  Signer,
+  TransactionRequest,
+  Eip1193Provider,
+  Networkish,
+  TypedDataDomain,
+  TypedDataField,
+} from 'ethers';
 
 export class EnhancedWallet extends Wallet {
   constructor(
@@ -11,10 +21,17 @@ export class EnhancedWallet extends Wallet {
       getTransactionCount?: (blockTag?: BlockTag) => Promise<number>;
     },
   );
+}
 
+export class BrowserProviderSigner extends AbstractSigner {
+  constructor(ethereum: Eip1193Provider, network?: Networkish);
+  getAddress(): Promise<string>;
+  connect(provider: Provider | null): Signer;
+  signMessage(message: string | Uint8Array): Promise<string>;
+  signTransaction(tx: TransactionRequest): Promise<string>;
   signTypedData(
     domain: TypedDataDomain,
-    types: Record<string, Array<TypedDataField>>,
+    types: Record<string, TypedDataField[]>,
     value: Record<string, any>,
   ): Promise<string>;
 }

--- a/src/common/utils/signers.js
+++ b/src/common/utils/signers.js
@@ -1,4 +1,4 @@
-import { Wallet } from 'ethers';
+import { Wallet, BrowserProvider, AbstractSigner } from 'ethers';
 import { getReadOnlyProvider } from './providers.js';
 
 export class EnhancedWallet extends Wallet {
@@ -49,6 +49,45 @@ export class EnhancedWallet extends Wallet {
       gasPrice = BigInt(this._options.gasPrice);
     }
     return super.sendTransaction({ gasPrice, ...tx });
+  }
+}
+
+export class BrowserProviderSigner extends AbstractSigner {
+  constructor(...args) {
+    super(new BrowserProvider(...args));
+  }
+
+  getAddress() {
+    return this.provider.getSigner().then((signer) => signer.getAddress());
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  connect() {
+    throw Error('Unsupported');
+  }
+
+  signMessage(message) {
+    return this.provider
+      .getSigner()
+      .then((signer) => signer.signMessage(message));
+  }
+
+  signTypedData(domain, types, value) {
+    return this.provider
+      .getSigner()
+      .then((signer) => signer.signTypedData(domain, types, value));
+  }
+
+  signTransaction(tx) {
+    return this.provider
+      .getSigner()
+      .then((signer) => signer.signTransaction(tx));
+  }
+
+  sendTransaction(tx) {
+    return this.provider
+      .getSigner()
+      .then((signer) => signer.sendTransaction(tx));
   }
 }
 

--- a/src/lib/IExecConfig.js
+++ b/src/lib/IExecConfig.js
@@ -2,7 +2,10 @@ import Debug from 'debug';
 import { JsonRpcProvider, BrowserProvider } from 'ethers';
 import IExecContractsClient from '../common/utils/IExecContractsClient.js';
 import { ConfigurationError } from '../common/utils/errors.js';
-import { EnhancedWallet } from '../common/utils/signers.js';
+import {
+  EnhancedWallet,
+  BrowserProviderSigner,
+} from '../common/utils/signers.js';
 import {
   getChainDefaults,
   isEnterpriseEnabled,
@@ -143,12 +146,12 @@ export default class IExecConfig {
           network: networkOverride,
         });
       } else {
-        const browserProvider = new BrowserProvider(
+        const browserSigner = new BrowserProviderSigner(
           ethProvider,
           networkOverride,
         );
-        signer = await browserProvider.getSigner();
-        provider = browserProvider.provider;
+        signer = browserSigner;
+        provider = browserSigner.provider;
       }
       return { provider, signer };
     })();


### PR DESCRIPTION
Fix regression causing browser providers (metamask) to prompt unlock screen on IExec instantiation

For browser providers `eth_requestAccount` is now requested just in time to get the wallet address, sign a message or a transaction.