### PR TITLE
Feature/export missing types

### DIFF
--- a/docs/classes/IExecOrderModule.md
+++ b/docs/classes/IExecOrderModule.md
@@ -281,7 +281,7 @@ const requestorderTemplate = await createRequestorder({
 | `overrides.app` | `string` | app to run |
 | `overrides.appmaxprice?` | [`NRLCAmount`](../modules.md#nrlcamount) | app max price per task default `0` |
 | `overrides.beneficiary?` | `string` | beneficiary default connected wallet address |
-| `overrides.callback?` | `string` | address of the smart contract for on-chain callback with the execution result. |
+| `overrides.callback?` | `string` | address of the smart contract for on-chain callback with the execution result |
 | `overrides.category` | [`BNish`](../modules.md#bnish) | computation category |
 | `overrides.dataset?` | `string` | dataset to use default none |
 | `overrides.datasetmaxprice?` | [`NRLCAmount`](../modules.md#nrlcamount) | dataset max price per task default `0` |

--- a/docs/classes/IExecOrderModule.md
+++ b/docs/classes/IExecOrderModule.md
@@ -281,6 +281,7 @@ const requestorderTemplate = await createRequestorder({
 | `overrides.app` | `string` | app to run |
 | `overrides.appmaxprice?` | [`NRLCAmount`](../modules.md#nrlcamount) | app max price per task default `0` |
 | `overrides.beneficiary?` | `string` | beneficiary default connected wallet address |
+| `overrides.callback?` | `string` | address of the smart contract for on-chain callback with the execution result. |
 | `overrides.category` | [`BNish`](../modules.md#bnish) | computation category |
 | `overrides.dataset?` | `string` | dataset to use default none |
 | `overrides.datasetmaxprice?` | [`NRLCAmount`](../modules.md#nrlcamount) | dataset max price per task default `0` |

--- a/src/lib/IExecOrderModule.d.ts
+++ b/src/lib/IExecOrderModule.d.ts
@@ -549,7 +549,7 @@ export default class IExecOrderModule extends IExecModule {
     params?: RequestorderParams | string;
 
     /**
-     * address of the smart contract for on-chain callback with the execution result.
+     * address of the smart contract for on-chain callback with the execution result
      */
     callback?: Address;
     /**

--- a/src/lib/IExecOrderModule.d.ts
+++ b/src/lib/IExecOrderModule.d.ts
@@ -547,6 +547,11 @@ export default class IExecOrderModule extends IExecModule {
      * execution parameters
      */
     params?: RequestorderParams | string;
+
+    /**
+     * address of the smart contract for on-chain callback with the execution result.
+     */
+    callback?: Address;
     /**
      * app max price per task
      *


### PR DESCRIPTION
le paramètre `callback` de la fonction `createRequestorder` dans le module `IExecOrderModule` existe dans l'implémentation réelle de la fonction mais il n'était pas inclus dans les types exportés par le module `IExecOrderModule.d.ts`  ni dans la documentation. 

J'ai ajouté le paramètre `callback` à la fonction `createRequestorder` dans le fichier` IExecOrderModule.d.ts` et j'ai regénérer la documentation pour la mettre a jour. 