### PR TITLE
Release/8.6.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -181,7 +181,7 @@ services:
       - redis-server --appendonly yes
 
   - name: token-watcher
-    image: iexechub/iexec-market-watcher:6.3
+    image: iexechub/iexec-market-watcher:6.4
     pull: always
     commands:
       - sleep 10
@@ -201,7 +201,7 @@ services:
       - gateway-redis
 
   - name: token-gateway
-    image: iexechub/iexec-market-api:6.3
+    image: iexechub/iexec-market-api:6.4
     pull: always
     commands:
       - sleep 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Next
+
+### Changed
+
+- remove ipfs initialization preflight checks on request orders
+
 ## [8.5.2] 2024-01-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Next
 
+### Added
+
+- strict mode `isRequesterStrict, isAppStrict, isDatasetStrict, isWorkerpoolStrict` in corresponding orderbook methods `fetchRequestOrderbook(), fetchAppOrderbook(), fetchDatasetOrderbook(), fetchWorkerpooltOrderbook(),`, defaults to false
+
 ### Changed
 
 - remove ipfs initialization preflight checks on request orders

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
-## Next
+## [8.6.0] 2024-03-04
 
 ### Added
 
-- strict mode `isRequesterStrict, isAppStrict, isDatasetStrict, isWorkerpoolStrict` in corresponding orderbook methods `fetchRequestOrderbook(), fetchAppOrderbook(), fetchDatasetOrderbook(), fetchWorkerpooltOrderbook(),`, defaults to false
+- strict mode `isRequesterStrict`, `isAppStrict`, `isDatasetStrict`, `isWorkerpoolStrict` in corresponding orderbook methods `fetchRequestOrderbook()`, `fetchAppOrderbook()`, `fetchDatasetOrderbook()`, `fetchWorkerpoolOrderbook()`, defaults to false
 
 ### Changed
 
 - remove ipfs initialization preflight checks on request orders
+- Typescript fixes
 
 ## [8.5.2] 2024-01-24
 

--- a/CLI.md
+++ b/CLI.md
@@ -1837,6 +1837,9 @@ Options:
 | --dataset \<address\> | include private orders for specified dataset |
 | --workerpool \<address\> | include private orders for specified workerpool |
 | --requester \<address\> | include private orders for specified requester |
+| --dataset-strict | fetch orders created strictly for the specified dataset |
+| --workerpool-strict | fetch orders created strictly for the specified workerpool |
+| --requester-strict | fetch orders created strictly for the specified requester |
 
 #### iexec orderbook dataset
 
@@ -1862,6 +1865,9 @@ Options:
 | --app \<address\> | include private orders for specified app |
 | --workerpool \<address\> | include private orders for specified workerpool |
 | --requester \<address\> | include private orders for specified requester |
+| --app-strict | fetch orders created strictly for the specified app |
+| --requester-strict | fetch orders created strictly for the specified requester |
+| --workerpool-strict | fetch orders created strictly for the specified workerpool |
 
 #### iexec orderbook workerpool
 
@@ -1889,6 +1895,9 @@ Options:
 | --app \<address\> | include private orders for specified app |
 | --dataset \<address\> | include private orders for specified dataset |
 | --requester \<address\> | include private orders for specified requester |
+| --dataset-strict | fetch orders created strictly for the specified dataset |
+| --app-strict | fetch orders created strictly for the specified app |
+| --requester-strict | fetch orders created strictly for the specified requester |
 
 #### iexec orderbook requester
 
@@ -1917,6 +1926,7 @@ Options:
 | --dataset \<address\> | filter by dataset |
 | --beneficiary \<address\> | filter by beneficiary |
 | --workerpool \<address\> | include private orders for specified workerpool |
+| --workerpool-strict | fetch orders created strictly for the specified workerpool |
 
 ### iexec deal
 

--- a/docs/classes/IExecOrderModule.md
+++ b/docs/classes/IExecOrderModule.md
@@ -281,6 +281,7 @@ const requestorderTemplate = await createRequestorder({
 | `overrides.app` | `string` | app to run |
 | `overrides.appmaxprice?` | [`NRLCAmount`](../modules.md#nrlcamount) | app max price per task default `0` |
 | `overrides.beneficiary?` | `string` | beneficiary default connected wallet address |
+| `overrides.callback?` | `string` | address of the smart contract for on-chain callback with the execution result |
 | `overrides.category` | [`BNish`](../modules.md#bnish) | computation category |
 | `overrides.dataset?` | `string` | dataset to use default none |
 | `overrides.datasetmaxprice?` | [`NRLCAmount`](../modules.md#nrlcamount) | dataset max price per task default `0` |

--- a/docs/classes/IExecOrderbookModule.md
+++ b/docs/classes/IExecOrderbookModule.md
@@ -91,6 +91,9 @@ console.log('total orders:', count);
 | `appAddress` | `string` | - |
 | `options?` | `Object` | - |
 | `options.dataset?` | `string` | include orders restricted to specified dataset (use `'any'` to include any dataset) |
+| `options.isDatasetStrict?` | `boolean` | filters out orders allowing “any” dataset (default: `false`) |
+| `options.isRequesterStrict?` | `boolean` | filters out orders allowing “any” requester (default: `false`) |
+| `options.isWorkerpoolStrict?` | `boolean` | filters out orders allowing “any” workerpool (default: `false`) |
 | `options.maxTag?` | [`Tag`](../modules.md#tag) \| `string`[] | filter by maximum tag accepted |
 | `options.minTag?` | [`Tag`](../modules.md#tag) \| `string`[] | filter by minimum tag required |
 | `options.minVolume?` | [`BNish`](../modules.md#bnish) | filter by minimum volume remaining |
@@ -152,6 +155,9 @@ console.log('total orders:', count);
 | `datasetAddress` | `string` | - |
 | `options?` | `Object` | - |
 | `options.app?` | `string` | include orders restricted to specified app (use `'any'` to include any app) |
+| `options.isAppStrict?` | `boolean` | filters out orders allowing “any” app (default: `false`) |
+| `options.isRequesterStrict?` | `boolean` | filters out orders allowing “any” requester (default: `false`) |
+| `options.isWorkerpoolStrict?` | `boolean` | filters out orders allowing “any” workerpool (default: `false`) |
 | `options.maxTag?` | [`Tag`](../modules.md#tag) \| `string`[] | filter by maximum tag accepted |
 | `options.minTag?` | [`Tag`](../modules.md#tag) \| `string`[] | filter by minimum tag required |
 | `options.minVolume?` | [`BNish`](../modules.md#bnish) | filter by minimum volume remaining |
@@ -214,6 +220,7 @@ console.log('total orders:', count);
 | `options.app?` | `string` | filter by specified app |
 | `options.category?` | [`BNish`](../modules.md#bnish) | filter by category |
 | `options.dataset?` | `string` | filter by specified dataset |
+| `options.isWorkerpoolStrict?` | `boolean` | filters out orders allowing “any” workerpool (default: `false`) |
 | `options.maxTag?` | [`Tag`](../modules.md#tag) \| `string`[] | filter by maximum tag accepted |
 | `options.maxTrust?` | [`BNish`](../modules.md#bnish) | filter by maximum trust required |
 | `options.minTag?` | [`Tag`](../modules.md#tag) \| `string`[] | filter by minimum tag required |
@@ -277,6 +284,9 @@ console.log('total orders:', count);
 | `options.app?` | `string` | include orders restricted to specified app (use `'any'` to include any app) |
 | `options.category?` | [`BNish`](../modules.md#bnish) | filter by category |
 | `options.dataset?` | `string` | include orders restricted to specified dataset (use `'any'` to include any dataset) |
+| `options.isAppStrict?` | `boolean` | filters out orders allowing “any” app (default: `false`) |
+| `options.isDatasetStrict?` | `boolean` | filters out orders allowing “any” dataset (default: `false`) |
+| `options.isRequesterStrict?` | `boolean` | filters out orders allowing “any” requester (default: `false`) |
 | `options.maxTag?` | [`Tag`](../modules.md#tag) \| `string`[] | filter by maximum tag offered |
 | `options.minTag?` | [`Tag`](../modules.md#tag) \| `string`[] | filter by minimum tag required |
 | `options.minTrust?` | [`BNish`](../modules.md#bnish) | filter by minimum trust required |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iexec",
-  "version": "8.5.2",
+  "version": "8.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iexec",
-      "version": "8.5.2",
+      "version": "8.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ensdomains/ens-contracts": "^0.0.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iexec",
-  "version": "8.5.2",
+  "version": "8.6.0",
   "description": "iExec SDK",
   "bin": {
     "iexec": "./dist/esm/cli/cmd/iexec.js"

--- a/src/cli/cmd/iexec-orderbook.js
+++ b/src/cli/cmd/iexec-orderbook.js
@@ -38,6 +38,9 @@ orderbookApp
   .option(...option.includeDatasetSpecific())
   .option(...option.includeWorkerpoolSpecific())
   .option(...option.includeRequesterSpecific())
+  .option(...option.isDatasetStrict())
+  .option(...option.isWorkerpoolStrict())
+  .option(...option.isRequesterStrict())
   .description(desc.showObj('app orderbook', 'marketplace'))
   .action(async (app, opts) => {
     await checkUpdate(opts);
@@ -55,6 +58,9 @@ orderbookApp
         maxTag,
         minVolume,
         raw,
+        isDatasetStrict,
+        isWorkerpoolStrict,
+        isRequesterStrict,
       } = opts;
 
       const request = fetchAppOrderbook(
@@ -68,6 +74,9 @@ orderbookApp
           minTag: tag !== undefined ? tag : requireTag,
           maxTag: tag !== undefined ? tag : maxTag,
           minVolume,
+          isDatasetStrict,
+          isWorkerpoolStrict,
+          isRequesterStrict,
         },
       );
       const fetchMessage = info.showing(objName);
@@ -144,6 +153,9 @@ orderbookDataset
   .option(...option.includeAppSpecific())
   .option(...option.includeWorkerpoolSpecific())
   .option(...option.includeRequesterSpecific())
+  .option(...option.isAppStrict())
+  .option(...option.isRequesterStrict())
+  .option(...option.isWorkerpoolStrict())
   .description(desc.showObj('dataset orderbook', 'marketplace'))
   .action(async (dataset, opts) => {
     await checkUpdate(opts);
@@ -161,6 +173,9 @@ orderbookDataset
         maxTag,
         requireTag,
         raw,
+        isAppStrict,
+        isRequesterStrict,
+        isWorkerpoolStrict,
       } = opts;
 
       const request = fetchDatasetOrderbook(
@@ -174,6 +189,9 @@ orderbookDataset
           minTag: tag !== undefined ? tag : requireTag,
           maxTag: tag !== undefined ? tag : maxTag,
           minVolume,
+          isAppStrict,
+          isRequesterStrict,
+          isWorkerpoolStrict,
         },
       );
       const fetchMessage = info.showing(objName);
@@ -252,6 +270,9 @@ orderbookWorkerpool
   .option(...option.includeAppSpecific())
   .option(...option.includeDatasetSpecific())
   .option(...option.includeRequesterSpecific())
+  .option(...option.isDatasetStrict())
+  .option(...option.isAppStrict())
+  .option(...option.isRequesterStrict())
   .description(desc.showObj('workerpools orderbook', 'marketplace'))
   .action(async (workerpool, opts) => {
     await checkUpdate(opts);
@@ -271,6 +292,9 @@ orderbookWorkerpool
         minVolume,
         minTrust,
         raw,
+        isAppStrict,
+        isRequesterStrict,
+        isDatasetStrict,
       } = opts;
 
       const request = fetchWorkerpoolOrderbook(
@@ -286,6 +310,9 @@ orderbookWorkerpool
           app,
           dataset,
           requester,
+          isAppStrict,
+          isRequesterStrict,
+          isDatasetStrict,
         },
       );
       const fetchMessage = info.showing(objName);
@@ -372,6 +399,7 @@ orderbookRequester
   .option(...option.filterDatasetSpecific())
   .option(...option.filterBeneficiarySpecific())
   .option(...option.includeWorkerpoolSpecific())
+  .option(...option.isWorkerpoolStrict())
   .description(desc.showObj('requesters orderbook', 'marketplace'))
   .action(async (address, opts) => {
     await checkUpdate(opts);
@@ -392,6 +420,7 @@ orderbookRequester
         maxTrust,
         minVolume,
         raw,
+        isWorkerpoolStrict,
       } = opts;
 
       const request = fetchRequestOrderbook(
@@ -408,6 +437,7 @@ orderbookRequester
           dataset,
           workerpool,
           beneficiary,
+          isWorkerpoolStrict,
         },
       );
       const fetchMessage = info.showing(objName);

--- a/src/cli/utils/cli-helper.js
+++ b/src/cli/utils/cli-helper.js
@@ -366,6 +366,22 @@ export const option = {
     '--skip-preflight-check',
     'skip preflight check, this may result in task execution fail',
   ],
+  isAppStrict: () => [
+    '--app-strict',
+    'fetch orders created strictly for the specified app',
+  ],
+  isDatasetStrict: () => [
+    '--dataset-strict',
+    'fetch orders created strictly for the specified dataset',
+  ],
+  isWorkerpoolStrict: () => [
+    '--workerpool-strict',
+    'fetch orders created strictly for the specified workerpool',
+  ],
+  isRequesterStrict: () => [
+    '--requester-strict',
+    'fetch orders created strictly for the specified requester',
+  ],
 };
 
 export const optionCreator = {

--- a/src/common/execution/order-helper.js
+++ b/src/common/execution/order-helper.js
@@ -95,10 +95,9 @@ export const checkRequestRequirements = async (
       );
     }
   }
-  // check storage token
+
+  // check dropbox storage token
   if (
-    paramsObj[IEXEC_REQUEST_PARAMS.IEXEC_RESULT_STORAGE_PROVIDER] ===
-      STORAGE_PROVIDERS.IPFS ||
     paramsObj[IEXEC_REQUEST_PARAMS.IEXEC_RESULT_STORAGE_PROVIDER] ===
       STORAGE_PROVIDERS.DROPBOX
   ) {
@@ -118,6 +117,7 @@ export const checkRequestRequirements = async (
       );
     }
   }
+
   // check tee dataset encryption key
   if (dataset && dataset !== NULL_ADDRESS && isTee) {
     const isDatasetSecretSet = await checkWeb3SecretExists(

--- a/src/common/generated/sdk/package.js
+++ b/src/common/generated/sdk/package.js
@@ -1,6 +1,6 @@
 // this file is auto generated do not edit it
 /* eslint-disable */
 export const name = "iexec";
-export const version = "8.5.2";
+export const version = "8.6.0";
 export const description = "iExec SDK";
 export default { name, version, description };

--- a/src/common/market/orderbook.js
+++ b/src/common/market/orderbook.js
@@ -9,6 +9,7 @@ import {
   positiveStrictIntSchema,
   tagSchema,
   throwIfMissing,
+  booleanSchema,
 } from '../utils/validator.js';
 
 const debug = Debug('iexec:market:orderbook');
@@ -28,6 +29,9 @@ export const fetchAppOrderbook = async (
     minVolume,
     page = 0,
     pageSize = 20,
+    isDatasetStrict = false,
+    isWorkerpoolStrict = false,
+    isRequesterStrict = false,
   } = {},
 ) => {
   try {
@@ -41,16 +45,19 @@ export const fetchAppOrderbook = async (
           ethProvider: contracts.provider,
         }).validate(dataset),
       }),
+      isDatasetStrict: await booleanSchema().validate(isDatasetStrict),
       ...(workerpool && {
         workerpool: await addressOrAnySchema({
           ethProvider: contracts.provider,
         }).validate(workerpool),
       }),
+      isWorkerpoolStrict: await booleanSchema().validate(isWorkerpoolStrict),
       ...(requester && {
         requester: await addressOrAnySchema({
           ethProvider: contracts.provider,
         }).validate(requester),
       }),
+      isRequesterStrict: await booleanSchema().validate(isRequesterStrict),
       ...(minVolume && {
         minVolume: await positiveStrictIntSchema().validate(minVolume),
       }),
@@ -98,6 +105,9 @@ export const fetchDatasetOrderbook = async (
     minVolume,
     page = 0,
     pageSize = 20,
+    isAppStrict = false,
+    isWorkerpoolStrict = false,
+    isRequesterStrict = false,
   } = {},
 ) => {
   try {
@@ -110,17 +120,20 @@ export const fetchDatasetOrderbook = async (
         app: await addressOrAnySchema({
           ethProvider: contracts.provider,
         }).validate(app),
+      isAppStrict: await booleanSchema().validate(isAppStrict),
       }),
       ...(workerpool && {
         workerpool: await addressOrAnySchema({
           ethProvider: contracts.provider,
         }).validate(workerpool),
       }),
+      isWorkerpoolStrict: await booleanSchema().validate(isWorkerpoolStrict),
       ...(requester && {
         requester: await addressOrAnySchema({
           ethProvider: contracts.provider,
         }).validate(requester),
       }),
+      isRequesterStrict: await booleanSchema().validate(isRequesterStrict),
       ...(minVolume && {
         minVolume: await positiveStrictIntSchema().validate(minVolume),
       }),
@@ -171,6 +184,9 @@ export const fetchWorkerpoolOrderbook = async (
     requester,
     page = 0,
     pageSize = 20,
+    isAppStrict = false,
+    isDatasetStrict = false,
+    isRequesterStrict = false,
   } = {},
 ) => {
   try {
@@ -187,16 +203,19 @@ export const fetchWorkerpoolOrderbook = async (
           ethProvider: contracts.provider,
         }).validate(app),
       }),
+      isAppStrict: await booleanSchema().validate(isAppStrict),
       ...(dataset && {
         dataset: await addressOrAnySchema({
           ethProvider: contracts.provider,
         }).validate(dataset),
       }),
+      isDatasetStrict: await booleanSchema().validate(isDatasetStrict),
       ...(requester && {
         requester: await addressOrAnySchema({
           ethProvider: contracts.provider,
         }).validate(requester),
       }),
+      isRequesterStrict: await booleanSchema().validate(isRequesterStrict),
       ...(minTag && {
         minTag: await tagSchema().validate(minTag),
       }),
@@ -255,6 +274,7 @@ export const fetchRequestOrderbook = async (
     minVolume,
     page = 0,
     pageSize = 20,
+    isWorkerpoolStrict = false,
   } = {},
 ) => {
   try {
@@ -286,6 +306,7 @@ export const fetchRequestOrderbook = async (
           ethProvider: contracts.provider,
         }).validate(workerpool),
       }),
+      isWorkerpoolStrict: await booleanSchema().validate(isWorkerpoolStrict),
       ...(minTag !== undefined && {
         minTag: await tagSchema().validate(minTag),
       }),

--- a/src/common/utils/validator.js
+++ b/src/common/utils/validator.js
@@ -67,6 +67,8 @@ export const hexnumberSchema = () =>
 export const uint256Schema = () =>
   stringNumberSchema({ message: '${originalValue} is not a valid uint256' });
 
+export const booleanSchema = () => boolean();
+
 const amountErrorMessage = ({ originalValue }) =>
   `${
     Array.isArray(originalValue) ? originalValue.join(' ') : originalValue

--- a/src/lib/IExecOrderModule.d.ts
+++ b/src/lib/IExecOrderModule.d.ts
@@ -547,6 +547,11 @@ export default class IExecOrderModule extends IExecModule {
      * execution parameters
      */
     params?: RequestorderParams | string;
+
+    /**
+     * address of the smart contract for on-chain callback with the execution result
+     */
+    callback?: Address;
     /**
      * app max price per task
      *

--- a/src/lib/IExecOrderbookModule.d.ts
+++ b/src/lib/IExecOrderbookModule.d.ts
@@ -179,6 +179,18 @@ export default class IExecOrderbookModule extends IExecModule {
        * size of the page to fetch
        */
       pageSize?: number;
+      /**
+       * filters out orders allowing “any” dataset (default: `false`)
+       */
+      isDatasetStrict?: boolean;
+      /**
+       * filters out orders allowing “any” requester (default: `false`)
+       */
+      isRequesterStrict?: boolean;
+      /**
+       * filters out orders allowing “any” workerpool (default: `false`)
+       */
+      isWorkerpoolStrict?: boolean;
     },
   ): Promise<PaginableOrders<PublishedApporder>>;
   /**
@@ -228,6 +240,18 @@ export default class IExecOrderbookModule extends IExecModule {
        * size of the page to fetch
        */
       pageSize?: number;
+      /**
+      * filters out orders allowing “any” app (default: `false`)
+      */
+      isAppStrict?: boolean;
+      /**
+      * filters out orders allowing “any” requester (default: `false`)
+      */
+      isRequesterStrict?: boolean;
+      /**
+      * filters out orders allowing “any” workerpool (default: `false`)
+      */
+      isWorkerpoolStrict?: boolean;
     },
   ): Promise<PaginableOrders<PublishedDatasetorder>>;
   /**
@@ -287,6 +311,18 @@ export default class IExecOrderbookModule extends IExecModule {
      * size of the page to fetch
      */
     pageSize?: number;
+    /**
+    * filters out orders allowing “any” dataset (default: `false`)
+    */
+    isDatasetStrict?: boolean;
+    /**
+    * filters out orders allowing “any” requester (default: `false`)
+    */
+    isRequesterStrict?: boolean;
+    /**
+    * filters out orders allowing “any” app (default: `false`)
+    */
+    isAppStrict?: boolean;
   }): Promise<PaginableOrders<PublishedWorkerpoolorder>>;
   /**
    * find the best paying request orders for computing resource.
@@ -345,6 +381,10 @@ export default class IExecOrderbookModule extends IExecModule {
      * size of the page to fetch
      */
     pageSize?: number;
+    /**
+    * filters out orders allowing “any” workerpool (default: `false`)
+    */
+    isWorkerpoolStrict?: boolean;
   }): Promise<PaginableOrders<PublishedWorkerpoolorder>>;
   /**
    * find a published apporder by orderHash.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1226,7 +1226,7 @@ describe('[Mainchain]', () => {
       'apporder: App requirements check failed: Tag mismatch the TEE framework specified by app (If you consider this is not an issue, use --skip-preflight-check to skip preflight requirement check)',
       `datasetorder: Dataset requirements check failed: Dataset encryption key is not set for dataset ${mainchainDataset} in the SMS. Dataset decryption will fail. (If you consider this is not an issue, use --skip-preflight-check to skip preflight requirement check)`,
       "workerpoolorder: 'tee' tag must be used with a tee framework ('scone'|'gramine')",
-      'requestorder: Request requirements check failed: Requester storage token is not set for selected provider "ipfs". Result archive upload will fail. (If you consider this is not an issue, use --skip-preflight-check to skip preflight requirement check)',
+      `requestorder: Request requirements check failed: Dataset encryption key is not set for dataset ${mainchainDataset} in the SMS. Dataset decryption will fail. (If you consider this is not an issue, use --skip-preflight-check to skip preflight requirement check)`,
     ]);
   });
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -138,7 +138,7 @@ services:
       - gateway
 
   token-watcher:
-    image: iexechub/iexec-market-watcher:6.3
+    image: iexechub/iexec-market-watcher:6.4
     restart: unless-stopped
     environment:
       - DEBUG=iexec-watcher*
@@ -159,7 +159,7 @@ services:
       - blockchain
 
   token-gateway:
-    image: iexechub/iexec-market-api:6.3
+    image: iexechub/iexec-market-api:6.4
     restart: unless-stopped
     ports:
       - 13000:3000

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -4780,44 +4780,6 @@ describe('[order]', () => {
     );
   });
 
-  test('order.signRequestorder() preflightCheck default storage', async () => {
-    const signer = utils.getSignerFromPrivateKey(
-      tokenChainOpenethereumUrl,
-      getRandomWallet().privateKey,
-    );
-    const iexec = new IExec(
-      {
-        ethProvider: signer,
-      },
-      {
-        hubAddress,
-        resultProxyURL,
-        smsURL: smsMap,
-      },
-    );
-    const order = await iexec.order.createRequestorder({
-      app: getRandomAddress(),
-      category: 5,
-    });
-
-    await expect(iexec.order.signRequestorder(order)).rejects.toThrow(
-      Error(
-        'Requester storage token is not set for selected provider "ipfs". Result archive upload will fail.',
-      ),
-    );
-    await iexec.storage
-      .defaultStorageLogin()
-      .then(iexec.storage.pushStorageToken);
-    const res = await iexec.order.signRequestorder(order);
-    expect(res.salt).toMatch(bytes32Regex);
-    expect(res.sign).toMatch(signRegex);
-    expect(res).toEqual({
-      ...order,
-      ...{ params: JSON.stringify(order.params) },
-      ...{ sign: res.sign, salt: res.salt },
-    });
-  });
-
   test('order.signRequestorder() preflightCheck dropbox storage', async () => {
     const signer = utils.getSignerFromPrivateKey(
       tokenChainInstamineUrl,
@@ -6790,24 +6752,6 @@ describe('[order]', () => {
           tag: ['tee', 'scone'],
         },
       );
-
-      // trigger request check
-      await expect(
-        iexec.order.matchOrders({
-          apporder,
-          datasetorder,
-          workerpoolorder,
-          requestorder,
-        }),
-      ).rejects.toThrow(
-        Error(
-          'Requester storage token is not set for selected provider "ipfs". Result archive upload will fail.',
-        ),
-      );
-
-      await iexec.storage
-        .defaultStorageLogin()
-        .then(iexec.storage.pushStorageToken);
       const res = await iexec.order.matchOrders({
         apporder,
         datasetorder,
@@ -7013,14 +6957,6 @@ describe('[order]', () => {
         category: 1,
       })
       .then((o) => iexec.order.signRequestorder(o, { preflightCheck: false }));
-    await expect(iexec.order.publishRequestorder(requestorder)).rejects.toThrow(
-      Error(
-        'Requester storage token is not set for selected provider "ipfs". Result archive upload will fail.',
-      ),
-    );
-    await iexec.storage
-      .defaultStorageLogin()
-      .then(iexec.storage.pushStorageToken);
     const orderHash = await iexec.order.publishRequestorder(requestorder);
     expect(orderHash).toMatch(bytes32Regex);
   });

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -602,9 +602,8 @@ describe('[workflow]', () => {
       category: noDurationCatId,
       volume: '1000',
     });
-    workerpoolorderToClaim = await iexec.order.signWorkerpoolorder(
-      orderToClaim,
-    );
+    workerpoolorderToClaim =
+      await iexec.order.signWorkerpoolorder(orderToClaim);
     expect(workerpoolorderToClaim.sign).toBeDefined();
   });
 
@@ -1315,14 +1314,12 @@ describe('[wallet]', () => {
       },
     );
     const initialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
-    const receiverInitialBalance = await iexec.wallet.checkBalances(
-      receiverAddress,
-    );
+    const receiverInitialBalance =
+      await iexec.wallet.checkBalances(receiverAddress);
     const txHash = await iexec.wallet.sendETH(5, receiverAddress);
     const finalBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
-    const receiverFinalBalance = await iexec.wallet.checkBalances(
-      receiverAddress,
-    );
+    const receiverFinalBalance =
+      await iexec.wallet.checkBalances(receiverAddress);
     expect(txHash).toMatch(bytes32Regex);
     expect(finalBalance.wei.add(new BN(5)).lt(initialBalance.wei)).toBe(true);
     expect(finalBalance.nRLC.eq(initialBalance.nRLC)).toBe(true);
@@ -1349,14 +1346,12 @@ describe('[wallet]', () => {
       },
     );
     const initialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
-    const receiverInitialBalance = await iexec.wallet.checkBalances(
-      receiverAddress,
-    );
+    const receiverInitialBalance =
+      await iexec.wallet.checkBalances(receiverAddress);
     const txHash = await iexec.wallet.sendETH('0.5 gwei', receiverAddress);
     const finalBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
-    const receiverFinalBalance = await iexec.wallet.checkBalances(
-      receiverAddress,
-    );
+    const receiverFinalBalance =
+      await iexec.wallet.checkBalances(receiverAddress);
     expect(txHash).toMatch(bytes32Regex);
     expect(
       finalBalance.wei.add(new BN('500000000')).lt(initialBalance.wei),
@@ -1408,14 +1403,12 @@ describe('[wallet]', () => {
       },
     );
     const initialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
-    const receiverInitialBalance = await iexec.wallet.checkBalances(
-      receiverAddress,
-    );
+    const receiverInitialBalance =
+      await iexec.wallet.checkBalances(receiverAddress);
     const txHash = await iexec.wallet.sendRLC(5, receiverAddress);
     const finalBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
-    const receiverFinalBalance = await iexec.wallet.checkBalances(
-      receiverAddress,
-    );
+    const receiverFinalBalance =
+      await iexec.wallet.checkBalances(receiverAddress);
     expect(txHash).toMatch(bytes32Regex);
     expect(finalBalance.wei.lt(initialBalance.wei)).toBe(true);
     expect(finalBalance.nRLC.add(new BN(5)).eq(initialBalance.nRLC)).toBe(true);
@@ -1440,14 +1433,12 @@ describe('[wallet]', () => {
       },
     );
     const initialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
-    const receiverInitialBalance = await iexec.wallet.checkBalances(
-      receiverAddress,
-    );
+    const receiverInitialBalance =
+      await iexec.wallet.checkBalances(receiverAddress);
     const txHash = await iexec.wallet.sendRLC('0.5 RLC', receiverAddress);
     const finalBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
-    const receiverFinalBalance = await iexec.wallet.checkBalances(
-      receiverAddress,
-    );
+    const receiverFinalBalance =
+      await iexec.wallet.checkBalances(receiverAddress);
     expect(txHash).toMatch(bytes32Regex);
     expect(finalBalance.wei.lt(initialBalance.wei)).toBe(true);
     expect(
@@ -1478,14 +1469,12 @@ describe('[wallet]', () => {
       },
     );
     const initialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
-    const receiverInitialBalance = await iexec.wallet.checkBalances(
-      receiverAddress,
-    );
+    const receiverInitialBalance =
+      await iexec.wallet.checkBalances(receiverAddress);
     const txHash = await iexec.wallet.sendRLC(5, receiverAddress);
     const finalBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
-    const receiverFinalBalance = await iexec.wallet.checkBalances(
-      receiverAddress,
-    );
+    const receiverFinalBalance =
+      await iexec.wallet.checkBalances(receiverAddress);
     expect(txHash).toMatch(bytes32Regex);
     expect(finalBalance.nRLC.add(new BN(5)).eq(initialBalance.nRLC)).toBe(true);
     expect(
@@ -1520,14 +1509,12 @@ describe('[wallet]', () => {
       },
     );
     const initialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
-    const receiverInitialBalance = await iexec.wallet.checkBalances(
-      receiverAddress,
-    );
+    const receiverInitialBalance =
+      await iexec.wallet.checkBalances(receiverAddress);
     const txHash = await iexec.wallet.sendRLC('0.000005 RLC', receiverAddress);
     const finalBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
-    const receiverFinalBalance = await iexec.wallet.checkBalances(
-      receiverAddress,
-    );
+    const receiverFinalBalance =
+      await iexec.wallet.checkBalances(receiverAddress);
     expect(txHash).toMatch(bytes32Regex);
     expect(finalBalance.nRLC.add(new BN(5000)).eq(initialBalance.nRLC)).toBe(
       true,
@@ -1566,14 +1553,12 @@ describe('[wallet]', () => {
       },
     );
     const initialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
-    const receiverInitialBalance = await iexec.wallet.checkBalances(
-      randomAddress,
-    );
+    const receiverInitialBalance =
+      await iexec.wallet.checkBalances(randomAddress);
     const txHash = await iexec.wallet.sendRLC(5, randomAddress);
     const finalBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
-    const receiverFinalBalance = await iexec.wallet.checkBalances(
-      randomAddress,
-    );
+    const receiverFinalBalance =
+      await iexec.wallet.checkBalances(randomAddress);
     expect(txHash).toMatch(bytes32Regex);
     expect(finalBalance.nRLC.add(new BN(5)).eq(initialBalance.nRLC)).toBe(true);
     expect(
@@ -2526,9 +2511,8 @@ describe('[account]', () => {
         hubAddress,
       },
     );
-    const accountInitialBalance = await iexec.account.checkBalance(
-      RICH_ADDRESS,
-    );
+    const accountInitialBalance =
+      await iexec.account.checkBalance(RICH_ADDRESS);
     const walletInitialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
     const res = await iexec.account.deposit(5);
     const accountFinalBalance = await iexec.account.checkBalance(RICH_ADDRESS);
@@ -2559,9 +2543,8 @@ describe('[account]', () => {
         hubAddress,
       },
     );
-    const accountInitialBalance = await iexec.account.checkBalance(
-      RICH_ADDRESS,
-    );
+    const accountInitialBalance =
+      await iexec.account.checkBalance(RICH_ADDRESS);
     const walletInitialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
     const res = await iexec.account.deposit('0.005 RLC');
     const accountFinalBalance = await iexec.account.checkBalance(RICH_ADDRESS);
@@ -2596,9 +2579,8 @@ describe('[account]', () => {
         hubAddress,
       },
     );
-    const accountInitialBalance = await iexec.account.checkBalance(
-      RICH_ADDRESS,
-    );
+    const accountInitialBalance =
+      await iexec.account.checkBalance(RICH_ADDRESS);
     const walletInitialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
     const { nRLC } = await iexec.wallet.checkBalances(RICH_ADDRESS);
     await expect(iexec.account.deposit(nRLC.add(new BN(1)))).rejects.toThrow(
@@ -2630,9 +2612,8 @@ describe('[account]', () => {
         useGas: false,
       },
     );
-    const accountInitialBalance = await iexec.account.checkBalance(
-      RICH_ADDRESS,
-    );
+    const accountInitialBalance =
+      await iexec.account.checkBalance(RICH_ADDRESS);
     const walletInitialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
     const res = await iexec.account.deposit(5);
     const accountFinalBalance = await iexec.account.checkBalance(RICH_ADDRESS);
@@ -2665,9 +2646,8 @@ describe('[account]', () => {
         useGas: false,
       },
     );
-    const accountInitialBalance = await iexec.account.checkBalance(
-      RICH_ADDRESS,
-    );
+    const accountInitialBalance =
+      await iexec.account.checkBalance(RICH_ADDRESS);
     const walletInitialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
     const res = await iexec.account.deposit('0.005 RLC');
     const accountFinalBalance = await iexec.account.checkBalance(RICH_ADDRESS);
@@ -2704,9 +2684,8 @@ describe('[account]', () => {
         useGas: false,
       },
     );
-    const accountInitialBalance = await iexec.account.checkBalance(
-      RICH_ADDRESS,
-    );
+    const accountInitialBalance =
+      await iexec.account.checkBalance(RICH_ADDRESS);
     const walletInitialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
     const { nRLC } = await iexec.wallet.checkBalances(RICH_ADDRESS);
     await expect(iexec.account.deposit(nRLC.add(new BN(1)))).rejects.toThrow(
@@ -2737,9 +2716,8 @@ describe('[account]', () => {
         hubAddress: enterpriseHubAddress,
       },
     );
-    const accountInitialBalance = await iexec.account.checkBalance(
-      RICH_ADDRESS,
-    );
+    const accountInitialBalance =
+      await iexec.account.checkBalance(RICH_ADDRESS);
     const walletInitialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
     const res = await iexec.account.deposit(5);
     const accountFinalBalance = await iexec.account.checkBalance(RICH_ADDRESS);
@@ -2791,9 +2769,8 @@ describe('[account]', () => {
       },
     );
     await iexec.account.deposit(10);
-    const accountInitialBalance = await iexec.account.checkBalance(
-      RICH_ADDRESS,
-    );
+    const accountInitialBalance =
+      await iexec.account.checkBalance(RICH_ADDRESS);
     const walletInitialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
     const res = await iexec.account.withdraw(5);
     const accountFinalBalance = await iexec.account.checkBalance(RICH_ADDRESS);
@@ -2825,9 +2802,8 @@ describe('[account]', () => {
       },
     );
     await iexec.account.deposit(10000);
-    const accountInitialBalance = await iexec.account.checkBalance(
-      RICH_ADDRESS,
-    );
+    const accountInitialBalance =
+      await iexec.account.checkBalance(RICH_ADDRESS);
     const walletInitialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
     const res = await iexec.account.withdraw('0.000005 RLC');
     const accountFinalBalance = await iexec.account.checkBalance(RICH_ADDRESS);
@@ -2861,9 +2837,8 @@ describe('[account]', () => {
       },
     );
     await iexec.account.deposit(10);
-    const accountInitialBalance = await iexec.account.checkBalance(
-      RICH_ADDRESS,
-    );
+    const accountInitialBalance =
+      await iexec.account.checkBalance(RICH_ADDRESS);
     const walletInitialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
     const { stake } = await iexec.account.checkBalance(RICH_ADDRESS);
     await expect(iexec.account.withdraw(stake.add(new BN(1)))).rejects.toThrow(
@@ -2896,9 +2871,8 @@ describe('[account]', () => {
       },
     );
     await iexec.account.deposit(10);
-    const accountInitialBalance = await iexec.account.checkBalance(
-      RICH_ADDRESS,
-    );
+    const accountInitialBalance =
+      await iexec.account.checkBalance(RICH_ADDRESS);
     const walletInitialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
     const res = await iexec.account.withdraw(5);
     const accountFinalBalance = await iexec.account.checkBalance(RICH_ADDRESS);
@@ -2932,9 +2906,8 @@ describe('[account]', () => {
       },
     );
     await iexec.account.deposit(10000);
-    const accountInitialBalance = await iexec.account.checkBalance(
-      RICH_ADDRESS,
-    );
+    const accountInitialBalance =
+      await iexec.account.checkBalance(RICH_ADDRESS);
     const walletInitialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
     const res = await iexec.account.withdraw('0.000005 RLC');
     const accountFinalBalance = await iexec.account.checkBalance(RICH_ADDRESS);
@@ -2970,9 +2943,8 @@ describe('[account]', () => {
       },
     );
     await iexec.account.deposit(10);
-    const accountInitialBalance = await iexec.account.checkBalance(
-      RICH_ADDRESS,
-    );
+    const accountInitialBalance =
+      await iexec.account.checkBalance(RICH_ADDRESS);
     const walletInitialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
     const { stake } = await iexec.account.checkBalance(RICH_ADDRESS);
     await expect(iexec.account.withdraw(stake.add(new BN(1)))).rejects.toThrow(
@@ -3022,9 +2994,8 @@ describe('[account]', () => {
       },
     );
     await iexec.account.deposit(10);
-    const accountInitialBalance = await iexec.account.checkBalance(
-      RICH_ADDRESS,
-    );
+    const accountInitialBalance =
+      await iexec.account.checkBalance(RICH_ADDRESS);
     const walletInitialBalance = await iexec.wallet.checkBalances(RICH_ADDRESS);
     const res = await iexec.account.withdraw(5);
     const accountFinalBalance = await iexec.account.checkBalance(RICH_ADDRESS);
@@ -3825,14 +3796,12 @@ describe('[dataset]', () => {
     );
     const datasetDeployRes = await deployRandomDataset(iexec);
     const datasetAddress = datasetDeployRes.address;
-    const withoutSecretRes = await iexec.dataset.checkDatasetSecretExists(
-      datasetAddress,
-    );
+    const withoutSecretRes =
+      await iexec.dataset.checkDatasetSecretExists(datasetAddress);
     expect(withoutSecretRes).toBe(false);
     await iexec.dataset.pushDatasetSecret(datasetAddress, 'oops');
-    const withSecretRes = await iexec.dataset.checkDatasetSecretExists(
-      datasetAddress,
-    );
+    const withSecretRes =
+      await iexec.dataset.checkDatasetSecretExists(datasetAddress);
     expect(withSecretRes).toBe(true);
 
     const datasetDeployedGramine = await deployRandomDataset(iexec);
@@ -3919,9 +3888,8 @@ describe('[workerpool]', () => {
       owner: await iexec.wallet.getAddress(),
       description: `workerpool${getId()}`,
     };
-    const predictedAddress = await iexec.workerpool.predictWorkerpoolAddress(
-      workerpool,
-    );
+    const predictedAddress =
+      await iexec.workerpool.predictWorkerpoolAddress(workerpool);
     await expect(
       iexec.workerpool.checkDeployedWorkerpool(predictedAddress),
     ).resolves.toBe(false);
@@ -4082,9 +4050,8 @@ describe('[workerpool]', () => {
       },
     );
     const userAddress = await iexec.wallet.getAddress();
-    const resBeforeDeploy = await iexec.workerpool.countUserWorkerpools(
-      userAddress,
-    );
+    const resBeforeDeploy =
+      await iexec.workerpool.countUserWorkerpools(userAddress);
     await deployRandomWorkerpool(iexec);
     const res = await iexec.workerpool.countUserWorkerpools(userAddress);
     expect(resBeforeDeploy).toBeInstanceOf(BN);
@@ -4892,9 +4859,8 @@ describe('[order]', () => {
     await iexecDatasetConsumer.storage
       .defaultStorageLogin()
       .then(iexecDatasetConsumer.storage.pushStorageToken);
-    const { address: dataset } = await deployRandomDataset(
-      iexecDatasetProvider,
-    );
+    const { address: dataset } =
+      await deployRandomDataset(iexecDatasetProvider);
 
     // non tee pass
     await expect(
@@ -5282,9 +5248,8 @@ describe('[order]', () => {
 
       const apporderTemplate = await deployAndGetApporder(iexec);
       const datasetorderTemplate = await deployAndGetDatasetorder(iexec);
-      const workerpoolorderTemplate = await deployAndGetWorkerpoolorder(
-        iexecPoolManager,
-      );
+      const workerpoolorderTemplate =
+        await deployAndGetWorkerpoolorder(iexecPoolManager);
       const requestorderTemplate = await getMatchableRequestorder(iexec, {
         apporder: apporderTemplate,
         datasetorder: datasetorderTemplate,
@@ -5432,9 +5397,8 @@ describe('[order]', () => {
           `dataset address mismatch between requestorder (${requestorderTemplate.dataset}) and datasetorder (${datasetorderAddressMismatch.dataset})`,
         ),
       );
-      const workerpoolorderAddressMismatch = await deployAndGetWorkerpoolorder(
-        iexec,
-      );
+      const workerpoolorderAddressMismatch =
+        await deployAndGetWorkerpoolorder(iexec);
       await expect(
         iexec.order.matchOrders(
           {
@@ -5962,12 +5926,10 @@ describe('[order]', () => {
       );
 
       const apporderTemplate = await deployAndGetApporder(iexecAppDev);
-      const datasetorderTemplate = await deployAndGetDatasetorder(
-        iexecDatasetDev,
-      );
-      const workerpoolorderTemplate = await deployAndGetWorkerpoolorder(
-        iexecPoolManager,
-      );
+      const datasetorderTemplate =
+        await deployAndGetDatasetorder(iexecDatasetDev);
+      const workerpoolorderTemplate =
+        await deployAndGetWorkerpoolorder(iexecPoolManager);
       const requestorderTemplate = await getMatchableRequestorder(
         iexecRequester,
         {
@@ -6086,9 +6048,8 @@ describe('[order]', () => {
       ).rejects.toThrow(Error('requestorder invalid sign'));
 
       // address mismatch
-      const apporderAddressMismatch = await deployAndGetApporder(
-        iexecRequester,
-      );
+      const apporderAddressMismatch =
+        await deployAndGetApporder(iexecRequester);
       await expect(
         iexecRequester.order.matchOrders(
           {
@@ -6104,9 +6065,8 @@ describe('[order]', () => {
           `app address mismatch between requestorder (${requestorderTemplate.app}) and apporder (${apporderAddressMismatch.app})`,
         ),
       );
-      const datasetorderAddressMismatch = await deployAndGetDatasetorder(
-        iexecRequester,
-      );
+      const datasetorderAddressMismatch =
+        await deployAndGetDatasetorder(iexecRequester);
       await expect(
         iexecRequester.order.matchOrders(
           {
@@ -6122,9 +6082,8 @@ describe('[order]', () => {
           `dataset address mismatch between requestorder (${requestorderTemplate.dataset}) and datasetorder (${datasetorderAddressMismatch.dataset})`,
         ),
       );
-      const workerpoolorderAddressMismatch = await deployAndGetWorkerpoolorder(
-        iexecRequester,
-      );
+      const workerpoolorderAddressMismatch =
+        await deployAndGetWorkerpoolorder(iexecRequester);
       await expect(
         iexecRequester.order.matchOrders(
           {
@@ -7174,12 +7133,10 @@ describe('[order]', () => {
     );
     const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
     const orderHash = await iexec.order.publishWorkerpoolorder(workerpoolorder);
-    const lastWorkerpoolorder = await iexec.order.signWorkerpoolorder(
-      workerpoolorder,
-    );
-    const lastOrderHash = await iexec.order.publishWorkerpoolorder(
-      lastWorkerpoolorder,
-    );
+    const lastWorkerpoolorder =
+      await iexec.order.signWorkerpoolorder(workerpoolorder);
+    const lastOrderHash =
+      await iexec.order.publishWorkerpoolorder(lastWorkerpoolorder);
     const unpublishLastRes = await iexec.order.unpublishLastWorkerpoolorder(
       workerpoolorder.workerpool,
     );
@@ -7361,12 +7318,10 @@ describe('[order]', () => {
     );
     const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
     const orderHash = await iexec.order.publishWorkerpoolorder(workerpoolorder);
-    const lastWorkerpoolorder = await iexec.order.signWorkerpoolorder(
-      workerpoolorder,
-    );
-    const lastOrderHash = await iexec.order.publishWorkerpoolorder(
-      lastWorkerpoolorder,
-    );
+    const lastWorkerpoolorder =
+      await iexec.order.signWorkerpoolorder(workerpoolorder);
+    const lastOrderHash =
+      await iexec.order.publishWorkerpoolorder(lastWorkerpoolorder);
     const unpublishAllRes = await iexec.order.unpublishAllWorkerpoolorders(
       workerpoolorder.workerpool,
     );
@@ -7663,6 +7618,180 @@ describe('[orderbook]', () => {
     expect(res7.count >= 32).toBe(true);
   });
 
+  test('orderbook.fetchAppOrderbook() strict', async () => {
+    const signer = utils.getSignerFromPrivateKey(
+      tokenChainOpenethereumUrl,
+      RICH_PRIVATE_KEY,
+    );
+    const iexec = new IExec(
+      {
+        ethProvider: signer,
+      },
+      {
+        hubAddress,
+        iexecGatewayURL,
+      },
+    );
+
+    // 1 and 2: orders without any restrictions
+    const emptyAppOrder = await deployAndGetApporder(iexec);
+    const appAddress = emptyAppOrder.app;
+
+    await iexec.order
+      .signApporder(emptyAppOrder)
+      .then((o) => iexec.order.publishApporder(o));
+    await iexec.order
+      .signApporder(emptyAppOrder)
+      .then((o) => iexec.order.publishApporder(o));
+
+    // 3: dataset restricted order
+    const datasetAddress = getRandomAddress();
+    emptyAppOrder.datasetrestrict = datasetAddress;
+    await iexec.order
+      .signApporder(emptyAppOrder)
+      .then((o) => iexec.order.publishApporder(o));
+    // reset to empty
+    emptyAppOrder.datasetrestrict = NULL_ADDRESS;
+
+    // 4: workerpool restricted order
+    const workerpoolAddress = getRandomAddress();
+    emptyAppOrder.workerpoolrestrict = workerpoolAddress;
+    await iexec.order
+      .signApporder(emptyAppOrder)
+      .then((o) => iexec.order.publishApporder(o));
+    // reset to empty
+    emptyAppOrder.workerpoolrestrict = NULL_ADDRESS;
+
+    // 5: requester restricted order
+    const requesterAddress = getRandomAddress();
+    emptyAppOrder.requesterrestrict = requesterAddress;
+    await iexec.order
+      .signApporder(emptyAppOrder)
+      .then((o) => iexec.order.publishApporder(o));
+    // reset to empty
+    emptyAppOrder.requesterrestrict = NULL_ADDRESS;
+
+    // all orders (1,2,3,4,5)
+    const allAppOrders = await iexec.orderbook.fetchAppOrderbook(appAddress, {
+      dataset: 'any',
+      requester: 'any',
+      workerpool: 'any',
+    });
+    expect(allAppOrders.count).toBe(5);
+    expect(allAppOrders.orders.length).toBe(5);
+
+    // all orders without restrictions (1, 2)
+    const unrestrictedAppOrders =
+      await iexec.orderbook.fetchAppOrderbook(appAddress);
+    expect(unrestrictedAppOrders.count).toBe(2);
+    expect(unrestrictedAppOrders.orders.length).toBe(2);
+    expect(unrestrictedAppOrders.orders[0].order.datasetrestrict).toEqual(
+      NULL_ADDRESS,
+    );
+    expect(unrestrictedAppOrders.orders[0].order.workerpoolrestrict).toEqual(
+      NULL_ADDRESS,
+    );
+    expect(unrestrictedAppOrders.orders[0].order.requesterrestrict).toEqual(
+      NULL_ADDRESS,
+    );
+    expect(unrestrictedAppOrders.orders[1].order.datasetrestrict).toEqual(
+      NULL_ADDRESS,
+    );
+    expect(unrestrictedAppOrders.orders[0].order.workerpoolrestrict).toEqual(
+      NULL_ADDRESS,
+    );
+    expect(unrestrictedAppOrders.orders[0].order.requesterrestrict).toEqual(
+      NULL_ADDRESS,
+    );
+
+    // all orders without dataset restriction(1,2) and with dataset restriction(3)
+    const datasetRestrictedAppOrders = await iexec.orderbook.fetchAppOrderbook(
+      appAddress,
+      { dataset: datasetAddress },
+    );
+    expect(datasetRestrictedAppOrders.count).toBe(3);
+    expect(datasetRestrictedAppOrders.orders.length).toBe(3);
+
+    // all orders with dataset restriction and strict(3)
+    const datasetStrictAppOrder = await iexec.orderbook.fetchAppOrderbook(
+      appAddress,
+      { dataset: datasetAddress, isDatasetStrict: true },
+    );
+    expect(datasetStrictAppOrder.count).toBe(1);
+    expect(datasetStrictAppOrder.orders.length).toBe(1);
+    expect(datasetStrictAppOrder.orders[0].order.datasetrestrict).toEqual(
+      datasetAddress,
+    );
+
+    // all orders without workerpool restriction(1,2) and with workerpool restriction(4)
+    const workerpoolRestrictedAppOrders =
+      await iexec.orderbook.fetchAppOrderbook(appAddress, {
+        workerpool: workerpoolAddress,
+      });
+    expect(workerpoolRestrictedAppOrders.count).toBe(3);
+    expect(workerpoolRestrictedAppOrders.orders.length).toBe(3);
+
+    // all orders with workerpool restriction and strict(4)
+    const workerpoolStrictAppOrder = await iexec.orderbook.fetchAppOrderbook(
+      appAddress,
+      { workerpool: workerpoolAddress, isWorkerpoolStrict: true },
+    );
+    expect(workerpoolStrictAppOrder.count).toBe(1);
+    expect(workerpoolStrictAppOrder.orders.length).toBe(1);
+    expect(workerpoolStrictAppOrder.orders[0].order.workerpoolrestrict).toEqual(
+      workerpoolAddress,
+    );
+
+    // all orders without requester restriction(1,2) and with requester restriction(5)
+    const requesterRestrictedAppOrders =
+      await iexec.orderbook.fetchAppOrderbook(appAddress, {
+        requester: requesterAddress,
+      });
+    expect(requesterRestrictedAppOrders.count).toBe(3);
+    expect(requesterRestrictedAppOrders.orders.length).toBe(3);
+
+    // all orders with requester restriction and strict(5)
+    const requesterStrictAppOrders = await iexec.orderbook.fetchAppOrderbook(
+      appAddress,
+      { requester: requesterAddress, isRequesterStrict: true },
+    );
+    expect(requesterStrictAppOrders.count).toBe(1);
+    expect(requesterStrictAppOrders.orders.length).toBe(1);
+    expect(requesterStrictAppOrders.orders[0].order.requesterrestrict).toEqual(
+      requesterAddress,
+    );
+
+    // all orders with requester, dataset, workerpool restriction and not strict (1,2,3,4,5)
+    const unstrictAppOrders = await iexec.orderbook.fetchAppOrderbook(
+      appAddress,
+      {
+        dataset: datasetAddress,
+        isDatasetStrict: false,
+        requester: requesterAddress,
+        isRequesterStrict: false,
+        workerpool: workerpoolAddress,
+        isWorkerpoolStrict: false,
+      },
+    );
+    expect(unstrictAppOrders.count).toBe(5);
+    expect(unstrictAppOrders.orders.length).toBe(5);
+
+    // all orders with requester, dataset, workerpool restriction and strict
+    const strictAppOrders = await iexec.orderbook.fetchAppOrderbook(
+      appAddress,
+      {
+        dataset: datasetAddress,
+        isDatasetStrict: true,
+        requester: requesterAddress,
+        isRequesterStrict: true,
+        workerpool: workerpoolAddress,
+        isWorkerpoolStrict: true,
+      },
+    );
+    expect(strictAppOrders.count).toBe(0);
+    expect(strictAppOrders.orders.length).toBe(0);
+  });
+
   test('orderbook.fetchDatasetOrderbook()', async () => {
     const signer = utils.getSignerFromPrivateKey(
       tokenChainOpenethereumUrl,
@@ -7762,6 +7891,193 @@ describe('[orderbook]', () => {
     expect(res7.count >= 33).toBe(true);
   });
 
+  test('orderbook.fetchDatasetOrderbook() strict', async () => {
+    const signer = utils.getSignerFromPrivateKey(
+      tokenChainOpenethereumUrl,
+      RICH_PRIVATE_KEY,
+    );
+    const iexec = new IExec(
+      {
+        ethProvider: signer,
+      },
+      {
+        hubAddress,
+        iexecGatewayURL,
+      },
+    );
+
+    // 1 and 2: orders without any restrictions
+    const emptyDatasetOrder = await deployAndGetDatasetorder(iexec);
+    const datasetAddress = emptyDatasetOrder.dataset;
+
+    await iexec.order
+      .signDatasetorder(emptyDatasetOrder, { preflightCheck: false })
+      .then((o) =>
+        iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+      );
+    await iexec.order
+      .signDatasetorder(emptyDatasetOrder, { preflightCheck: false })
+      .then((o) =>
+        iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+      );
+
+    // 3: app restricted order
+    const appAddress = getRandomAddress();
+    emptyDatasetOrder.apprestrict = appAddress;
+    await iexec.order
+      .signDatasetorder(emptyDatasetOrder, { preflightCheck: false })
+      .then((o) =>
+        iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+      );
+    // reset to empty
+    emptyDatasetOrder.apprestrict = NULL_ADDRESS;
+
+    // 4: workerpool restricted order
+    const workerpoolAddress = getRandomAddress();
+    emptyDatasetOrder.workerpoolrestrict = workerpoolAddress;
+    await iexec.order
+      .signDatasetorder(emptyDatasetOrder, { preflightCheck: false })
+      .then((o) =>
+        iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+      );
+    // reset to empty
+    emptyDatasetOrder.workerpoolrestrict = NULL_ADDRESS;
+
+    // 5: requester restricted order
+    const requesterAddress = getRandomAddress();
+    emptyDatasetOrder.requesterrestrict = requesterAddress;
+    await iexec.order
+      .signDatasetorder(emptyDatasetOrder, { preflightCheck: false })
+      .then((o) =>
+        iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+      );
+    // reset to empty
+    emptyDatasetOrder.requesterrestrict = NULL_ADDRESS;
+
+    // all orders (1,2,3,4,5)
+    const allADatasetOrders = await iexec.orderbook.fetchDatasetOrderbook(
+      datasetAddress,
+      {
+        app: 'any',
+        requester: 'any',
+        workerpool: 'any',
+      },
+    );
+    expect(allADatasetOrders.count).toBe(5);
+    expect(allADatasetOrders.orders.length).toBe(5);
+
+    // all orders without restrictions (1, 2)
+    const unrestrictedDatasetOrders =
+      await iexec.orderbook.fetchDatasetOrderbook(datasetAddress);
+    expect(unrestrictedDatasetOrders.count).toBe(2);
+    expect(unrestrictedDatasetOrders.orders.length).toBe(2);
+    expect(unrestrictedDatasetOrders.orders[0].order.apprestrict).toEqual(
+      NULL_ADDRESS,
+    );
+    expect(
+      unrestrictedDatasetOrders.orders[0].order.workerpoolrestrict,
+    ).toEqual(NULL_ADDRESS);
+    expect(unrestrictedDatasetOrders.orders[0].order.requesterrestrict).toEqual(
+      NULL_ADDRESS,
+    );
+    expect(unrestrictedDatasetOrders.orders[1].order.apprestrict).toEqual(
+      NULL_ADDRESS,
+    );
+    expect(
+      unrestrictedDatasetOrders.orders[0].order.workerpoolrestrict,
+    ).toEqual(NULL_ADDRESS);
+    expect(unrestrictedDatasetOrders.orders[0].order.requesterrestrict).toEqual(
+      NULL_ADDRESS,
+    );
+
+    // all orders without app restriction(1,2) and with app restriction(3)
+    const appRestrictedAppOrders = await iexec.orderbook.fetchDatasetOrderbook(
+      datasetAddress,
+      { app: appAddress },
+    );
+    expect(appRestrictedAppOrders.count).toBe(3);
+    expect(appRestrictedAppOrders.orders.length).toBe(3);
+
+    // all orders with app restriction and strict(3)
+    const appStrictAppOrder = await iexec.orderbook.fetchDatasetOrderbook(
+      datasetAddress,
+      { app: appAddress, isAppStrict: true },
+    );
+    expect(appStrictAppOrder.count).toBe(1);
+    expect(appStrictAppOrder.orders.length).toBe(1);
+    expect(appStrictAppOrder.orders[0].order.apprestrict).toEqual(appAddress);
+
+    // all orders without workerpool restriction(1,2) and with workerpool restriction(4)
+    const workerpoolRestrictedAppOrders =
+      await iexec.orderbook.fetchDatasetOrderbook(datasetAddress, {
+        workerpool: workerpoolAddress,
+      });
+    expect(workerpoolRestrictedAppOrders.count).toBe(3);
+    expect(workerpoolRestrictedAppOrders.orders.length).toBe(3);
+
+    // all orders with workerpool restriction and strict(4)
+    const workerpoolStrictAppOrder =
+      await iexec.orderbook.fetchDatasetOrderbook(datasetAddress, {
+        workerpool: workerpoolAddress,
+        isWorkerpoolStrict: true,
+      });
+    expect(workerpoolStrictAppOrder.count).toBe(1);
+    expect(workerpoolStrictAppOrder.orders.length).toBe(1);
+    expect(workerpoolStrictAppOrder.orders[0].order.workerpoolrestrict).toEqual(
+      workerpoolAddress,
+    );
+
+    // all orders without requester restriction(1,2) and with requester restriction(5)
+    const requesterRestrictedAppOrders =
+      await iexec.orderbook.fetchDatasetOrderbook(datasetAddress, {
+        requester: requesterAddress,
+      });
+    expect(requesterRestrictedAppOrders.count).toBe(3);
+    expect(requesterRestrictedAppOrders.orders.length).toBe(3);
+
+    // all orders with requester restriction and strict(5)
+    const requesterStrictAppOrders =
+      await iexec.orderbook.fetchDatasetOrderbook(datasetAddress, {
+        requester: requesterAddress,
+        isRequesterStrict: true,
+      });
+    expect(requesterStrictAppOrders.count).toBe(1);
+    expect(requesterStrictAppOrders.orders.length).toBe(1);
+    expect(requesterStrictAppOrders.orders[0].order.requesterrestrict).toEqual(
+      requesterAddress,
+    );
+
+    // all orders with app, requester, workerpool restriction and not strict (1,2,3,4,5)
+    const unstrictAppOrders = await iexec.orderbook.fetchDatasetOrderbook(
+      datasetAddress,
+      {
+        app: appAddress,
+        isAppStrict: false,
+        requester: requesterAddress,
+        isRequesterStrict: false,
+        workerpool: workerpoolAddress,
+        isWorkerpoolStrict: false,
+      },
+    );
+    expect(unstrictAppOrders.count).toBe(5);
+    expect(unstrictAppOrders.orders.length).toBe(5);
+
+    // all orders with app, requester, workerpool restriction and strict
+    const strictAppOrders = await iexec.orderbook.fetchDatasetOrderbook(
+      datasetAddress,
+      {
+        app: appAddress,
+        isAppStrict: true,
+        requester: requesterAddress,
+        isRequesterStrict: true,
+        workerpool: workerpoolAddress,
+        isWorkerpoolStrict: true,
+      },
+    );
+    expect(strictAppOrders.count).toBe(0);
+    expect(strictAppOrders.orders.length).toBe(0);
+  });
+
   test('orderbook.fetchWorkerpoolOrderbook()', async () => {
     const signer = utils.getSignerFromPrivateKey(
       tokenChainOpenethereumUrl,
@@ -7858,6 +8174,185 @@ describe('[orderbook]', () => {
     expect(res7.count).toBe(res8.count);
   });
 
+  test('orderbook.fetchWorkerpoolOrderbook() strict', async () => {
+    const signer = utils.getSignerFromPrivateKey(
+      tokenChainOpenethereumUrl,
+      RICH_PRIVATE_KEY,
+    );
+    const iexec = new IExec(
+      {
+        ethProvider: signer,
+      },
+      {
+        hubAddress,
+        iexecGatewayURL,
+      },
+    );
+
+    // 1 and 2: orders without any restrictions
+    const emptyWorkerpoolOrder = await deployAndGetWorkerpoolorder(iexec);
+    const workerpoolAddress = emptyWorkerpoolOrder.workerpool;
+    await iexec.order
+      .signWorkerpoolorder(emptyWorkerpoolOrder)
+      .then((o) => iexec.order.publishWorkerpoolorder(o));
+    await iexec.order
+      .signWorkerpoolorder(emptyWorkerpoolOrder)
+      .then((o) => iexec.order.publishWorkerpoolorder(o));
+
+    // 3: app restricted order
+    const appAddress = getRandomAddress();
+    emptyWorkerpoolOrder.apprestrict = appAddress;
+    await iexec.order
+      .signWorkerpoolorder(emptyWorkerpoolOrder)
+      .then((o) => iexec.order.publishWorkerpoolorder(o));
+    // reset to empty
+    emptyWorkerpoolOrder.apprestrict = NULL_ADDRESS;
+
+    // 4: dataset restricted order
+    const datasetAddress = getRandomAddress();
+    emptyWorkerpoolOrder.datasetrestrict = datasetAddress;
+    await iexec.order
+      .signWorkerpoolorder(emptyWorkerpoolOrder)
+      .then((o) => iexec.order.publishWorkerpoolorder(o));
+    // reset to empty
+    emptyWorkerpoolOrder.datasetrestrict = NULL_ADDRESS;
+
+    // 5: requester restricted order
+    const requesterAddress = getRandomAddress();
+    emptyWorkerpoolOrder.requesterrestrict = requesterAddress;
+    await iexec.order
+      .signWorkerpoolorder(emptyWorkerpoolOrder)
+      .then((o) => iexec.order.publishWorkerpoolorder(o));
+    // reset to empty
+    emptyWorkerpoolOrder.requesterrestrict = NULL_ADDRESS;
+
+    // all orders (1,2,3,4,5)
+    const allWorkerpoolOrders = await iexec.orderbook.fetchWorkerpoolOrderbook({
+      workerpool: workerpoolAddress,
+      app: 'any',
+      requester: 'any',
+      dataset: 'any',
+    });
+
+    expect(allWorkerpoolOrders.count).toBe(5);
+    expect(allWorkerpoolOrders.orders.length).toBe(5);
+
+    // all orders without restrictions (1, 2)
+    const unrestrictedWorkerpoolOrders =
+      await iexec.orderbook.fetchWorkerpoolOrderbook({
+        workerpool: workerpoolAddress,
+      });
+    expect(unrestrictedWorkerpoolOrders.count).toBe(2);
+    expect(unrestrictedWorkerpoolOrders.orders.length).toBe(2);
+    expect(unrestrictedWorkerpoolOrders.orders[0].order.apprestrict).toEqual(
+      NULL_ADDRESS,
+    );
+    expect(
+      unrestrictedWorkerpoolOrders.orders[0].order.datasetrestrict,
+    ).toEqual(NULL_ADDRESS);
+    expect(
+      unrestrictedWorkerpoolOrders.orders[0].order.requesterrestrict,
+    ).toEqual(NULL_ADDRESS);
+    expect(unrestrictedWorkerpoolOrders.orders[1].order.apprestrict).toEqual(
+      NULL_ADDRESS,
+    );
+    expect(
+      unrestrictedWorkerpoolOrders.orders[0].order.datasetrestrict,
+    ).toEqual(NULL_ADDRESS);
+    expect(
+      unrestrictedWorkerpoolOrders.orders[0].order.requesterrestrict,
+    ).toEqual(NULL_ADDRESS);
+
+    // all orders without app restriction(1,2) and with app restriction(3)
+    const appRestrictedAppOrders =
+      await iexec.orderbook.fetchWorkerpoolOrderbook({
+        workerpool: workerpoolAddress,
+        app: appAddress,
+      });
+    expect(appRestrictedAppOrders.count).toBe(3);
+    expect(appRestrictedAppOrders.orders.length).toBe(3);
+
+    // all orders with app restriction and strict(3)
+    const appStrictAppOrder = await iexec.orderbook.fetchWorkerpoolOrderbook({
+      workerpool: workerpoolAddress,
+      app: appAddress,
+      isAppStrict: true,
+    });
+    expect(appStrictAppOrder.count).toBe(1);
+    expect(appStrictAppOrder.orders.length).toBe(1);
+    expect(appStrictAppOrder.orders[0].order.apprestrict).toEqual(appAddress);
+
+    // all orders without dataset restriction(1,2) and with dataset restriction(4)
+    const datasetRestrictedWorkerpoolOrders =
+      await iexec.orderbook.fetchWorkerpoolOrderbook({
+        workerpool: workerpoolAddress,
+        dataset: datasetAddress,
+      });
+    expect(datasetRestrictedWorkerpoolOrders.count).toBe(3);
+    expect(datasetRestrictedWorkerpoolOrders.orders.length).toBe(3);
+
+    // all orders with dataset restriction and strict(4)
+    const datasetStrictAppOrder =
+      await iexec.orderbook.fetchWorkerpoolOrderbook({
+        workerpool: workerpoolAddress,
+        dataset: datasetAddress,
+        isDatasetStrict: true,
+      });
+    expect(datasetStrictAppOrder.count).toBe(1);
+    expect(datasetStrictAppOrder.orders.length).toBe(1);
+    expect(datasetStrictAppOrder.orders[0].order.datasetrestrict).toEqual(
+      datasetAddress,
+    );
+
+    // all orders without requester restriction(1,2) and with requester restriction(5)
+    const requesterRestrictedAppOrders =
+      await iexec.orderbook.fetchWorkerpoolOrderbook({
+        workerpool: workerpoolAddress,
+        requester: requesterAddress,
+      });
+    expect(requesterRestrictedAppOrders.count).toBe(3);
+    expect(requesterRestrictedAppOrders.orders.length).toBe(3);
+
+    // all orders with requester restriction and strict(5)
+    const requesterStrictAppOrders =
+      await iexec.orderbook.fetchWorkerpoolOrderbook({
+        workerpool: workerpoolAddress,
+        requester: requesterAddress,
+        isRequesterStrict: true,
+      });
+    expect(requesterStrictAppOrders.count).toBe(1);
+    expect(requesterStrictAppOrders.orders.length).toBe(1);
+    expect(requesterStrictAppOrders.orders[0].order.requesterrestrict).toEqual(
+      requesterAddress,
+    );
+
+    // all orders with requester, dataset, workerpool restriction and not strict (1,2,3,4,5)
+    const unstrictAppOrders = await iexec.orderbook.fetchWorkerpoolOrderbook({
+      workerpool: workerpoolAddress,
+      app: appAddress,
+      isAppStrict: false,
+      requester: requesterAddress,
+      isRequesterStrict: false,
+      dataset: datasetAddress,
+      isDatasetStrict: false,
+    });
+    expect(unstrictAppOrders.count).toBe(5);
+    expect(unstrictAppOrders.orders.length).toBe(5);
+
+    // all orders with requester, dataset, workerpool restriction and strict
+    const strictAppOrders = await iexec.orderbook.fetchWorkerpoolOrderbook({
+      workerpool: workerpoolAddress,
+      app: appAddress,
+      isAppStrict: true,
+      requester: requesterAddress,
+      isRequesterStrict: true,
+      dataset: datasetAddress,
+      isDatasetStrict: true,
+    });
+    expect(strictAppOrders.count).toBe(0);
+    expect(strictAppOrders.orders.length).toBe(0);
+  });
+
   test('orderbook.fetchRequestOrderbook()', async () => {
     const signer = utils.getSignerFromPrivateKey(
       tokenChainOpenethereumUrl,
@@ -7944,6 +8439,124 @@ describe('[orderbook]', () => {
   });
 });
 
+test('orderbook.fetchRequesterOrderbook() strict', async () => {
+  const signer = utils.getSignerFromPrivateKey(
+    tokenChainOpenethereumUrl,
+    RICH_PRIVATE_KEY,
+  );
+  const iexec = new IExec(
+    {
+      ethProvider: signer,
+    },
+    {
+      hubAddress,
+      iexecGatewayURL,
+      resultProxyURL: 'https://result-proxy.iex.ec',
+      smsURL: 'https://sms.iex.ec',
+    },
+  );
+
+  const requesterAddress = iexec.wallet.getAddress();
+
+  const apporder = await deployAndGetApporder(iexec);
+  const appAddress = apporder.app;
+  await iexec.order
+    .signApporder(apporder)
+    .then((o) => iexec.order.publishApporder(o));
+
+  const datasetorder = await deployAndGetDatasetorder(iexec);
+  const datasetAddress = datasetorder.dataset;
+  await iexec.order
+    .signDatasetorder(datasetorder)
+    .then((o) => iexec.order.publishDatasetorder(o, { preflightCheck: false }));
+
+  const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
+  const workerpoolAddress = workerpoolorder.workerpool;
+  await iexec.order
+    .signWorkerpoolorder(workerpoolorder)
+    .then((o) =>
+      iexec.order.publishWorkerpoolorder(o, { preflightCheck: false }),
+    );
+
+  // first: request order for app without restrictions
+  await iexec.order
+    .createRequestorder({
+      requester: requesterAddress,
+      app: appAddress,
+      appmaxprice: apporder.appprice,
+      dataset: NULL_ADDRESS,
+      datasetmaxprice: 0,
+      workerpool: NULL_ADDRESS,
+      workerpoolmaxprice: 0,
+      category: 1,
+      trust: 0,
+      volume: 1,
+    })
+    .then((o) => iexec.order.signRequestorder(o, { preflightCheck: false }))
+    .then((o) => iexec.order.publishRequestorder(o, { preflightCheck: false }));
+
+  // second: request order for app with workerpool and dataset restrictions
+  await iexec.order
+    .createRequestorder({
+      requester: requesterAddress,
+      app: appAddress,
+      appmaxprice: apporder.appprice,
+      dataset: datasetAddress,
+      datasetmaxprice: 0,
+      workerpool: workerpoolAddress,
+      workerpoolmaxprice: 0,
+      category: 1,
+      trust: 0,
+      volume: 1,
+    })
+    .then((o) => iexec.order.signRequestorder(o, { preflightCheck: false }))
+    .then((o) => iexec.order.publishRequestorder(o, { preflightCheck: false }));
+
+  // request orders restricted by app - always strict (1,2)
+  const appRestrictedRequestOrders =
+    await iexec.orderbook.fetchRequestOrderbook({
+      requester: requesterAddress,
+      workerpool: 'any',
+      app: appAddress,
+    });
+  expect(appRestrictedRequestOrders.count).toBe(2);
+  expect(appRestrictedRequestOrders.orders.length).toBe(2);
+
+  // request orders restricted by dataset - always strict (2)
+  const datasetRestrictedRequestOrders =
+    await iexec.orderbook.fetchRequestOrderbook({
+      requester: requesterAddress,
+      dataset: datasetAddress,
+      workerpool: 'any',
+    });
+  expect(datasetRestrictedRequestOrders.count).toBe(1);
+  expect(datasetRestrictedRequestOrders.orders.length).toBe(1);
+
+  // request orders restricted by workerpool (2)
+  const workerpoolRestrictedRequestOrders =
+    await iexec.orderbook.fetchRequestOrderbook({
+      requester: requesterAddress,
+      workerpool: workerpoolAddress,
+      app: appAddress,
+    });
+  expect(workerpoolRestrictedRequestOrders.count).toBe(2);
+  expect(workerpoolRestrictedRequestOrders.orders.length).toBe(2);
+
+  // request orders restricted by workerpool and strict (1)
+  const workerpoolSrictRequestOrders =
+    await iexec.orderbook.fetchRequestOrderbook({
+      requester: requesterAddress,
+      workerpool: workerpoolAddress,
+      isWorkerpoolStrict: true,
+      app: appAddress,
+    });
+  expect(workerpoolSrictRequestOrders.count).toBe(1);
+  expect(workerpoolSrictRequestOrders.orders.length).toBe(1);
+  expect(workerpoolSrictRequestOrders.orders[0].order.workerpool).toEqual(
+    workerpoolAddress,
+  );
+});
+
 describe('[deal]', () => {
   test('deal.fetchRequesterDeals()', async () => {
     const signer = utils.getSignerFromPrivateKey(
@@ -7983,9 +8596,8 @@ describe('[deal]', () => {
       { preflightCheck: false },
     );
     await sleep(5000);
-    const resAfterMatch = await iexec.deal.fetchRequesterDeals(
-      requesterAddress,
-    );
+    const resAfterMatch =
+      await iexec.deal.fetchRequesterDeals(requesterAddress);
     expect(res.count).toBe(resAfterMatch.count - 1);
     const resAppFiltered = await iexec.deal.fetchRequesterDeals(
       requesterAddress,
@@ -8140,9 +8752,8 @@ describe('[deal]', () => {
       { preflightCheck: false },
     );
     await sleep(5000);
-    const resAfterMatch = await iexec.deal.fetchDealsByWorkerpoolorder(
-      orderHash,
-    );
+    const resAfterMatch =
+      await iexec.deal.fetchDealsByWorkerpoolorder(orderHash);
     expect(resAfterMatch.count).toBe(1);
     expect(resAfterMatch.deals[0].dealid).toBe(dealid);
     expect(resAfterMatch.deals[0].workerpool.pointer).toBe(
@@ -9490,9 +10101,8 @@ describe('[ens]', () => {
     expect(appDomain).toBe('apps.iexec.eth');
     const datasetDomain = await iexec.ens.getDefaultDomain(datasetAddress);
     expect(datasetDomain).toBe('datasets.iexec.eth');
-    const workerpoolDomain = await iexec.ens.getDefaultDomain(
-      workerpoolAddress,
-    );
+    const workerpoolDomain =
+      await iexec.ens.getDefaultDomain(workerpoolAddress);
     expect(workerpoolDomain).toBe('pools.iexec.eth');
     const defaultDomain = await iexec.ens.getDefaultDomain(getRandomAddress());
     expect(defaultDomain).toBe('users.iexec.eth');


### PR DESCRIPTION
## [8.6.0]

### Added

- strict mode `isRequesterStrict`, `isAppStrict`, `isDatasetStrict`, `isWorkerpoolStrict` in corresponding orderbook methods `fetchRequestOrderbook()`, `fetchAppOrderbook()`, `fetchDatasetOrderbook()`, `fetchWorkerpoolOrderbook()`, defaults to false

### Changed

- remove ipfs initialization preflight checks on request orders
- Typescript fixes