### PR TITLE
Tell webpack to ignore node:crypto import

### DIFF
--- a/src/common/sms/crypto.js
+++ b/src/common/sms/crypto.js
@@ -4,7 +4,7 @@ export async function getCrypto() {
     return { crypto, CryptoKey };
   }
   // Node <= 18
-  const nodeCrypto = await import('node:crypto');
+  const nodeCrypto = await import(/* webpackIgnore: true */ 'node:crypto');
   return {
     crypto: nodeCrypto.webcrypto,
     CryptoKey: nodeCrypto.webcrypto.CryptoKey,

--- a/src/common/sms/crypto.js
+++ b/src/common/sms/crypto.js
@@ -3,10 +3,10 @@ export async function getCrypto() {
     // Browser and Node >= 20
     return { crypto, CryptoKey };
   }
-  // Node <= 18
-  const nodeCrypto = await import(/* webpackIgnore: true */ 'node:crypto');
+  // Node <= 18 and webpack (needs polyfill)
+  const crypto = await import('crypto');
   return {
-    crypto: nodeCrypto.webcrypto,
-    CryptoKey: nodeCrypto.webcrypto.CryptoKey,
+    crypto: crypto.webcrypto,
+    CryptoKey: crypto.webcrypto.CryptoKey,
   };
 }

--- a/src/common/sms/crypto.js
+++ b/src/common/sms/crypto.js
@@ -1,7 +1,7 @@
 export async function getCrypto() {
   if (globalThis.crypto) {
     // Browser and Node >= 20
-    return { crypto, CryptoKey };
+    return { crypto: globalThis.crypto, CryptoKey };
   }
   // Node <= 18 and webpack (needs polyfill)
   const crypto = await import('crypto');

--- a/src/common/sms/crypto.js
+++ b/src/common/sms/crypto.js
@@ -4,7 +4,7 @@ export async function getCrypto() {
     return { crypto: globalThis.crypto, CryptoKey };
   }
   // Node <= 18 and webpack (needs polyfill)
-  const crypto = await import('crypto');
+  const crypto = await import(/* webpackIgnore: true */ 'crypto');
   return {
     crypto: crypto.webcrypto,
     CryptoKey: crypto.webcrypto.CryptoKey,


### PR DESCRIPTION
### Context

Referencing https://github.com/iExecBlockchainComputing/iexec-sdk/pull/232

Having such an import was probably a mistake: `const nodeCrypto = await import('node:crypto');`

Replacing it with `const crypto = await import('crypto');` seems to cover more environments, such as webpack v5.

However with webpack, a polyfill would still be required. Add the following `resolve` config into your `webpack.config.js`:

```
  resolve: {
    fallback: {
      crypto: require.resolve("crypto-browserify"),
      stream: require.resolve("stream-browserify"),
    },
  },
```

---

More details about my tests:

**webpack v5**
`globalThis.crypto` NOT defined
Needs to load a polyfill

**parcel**
By itself parcel will parse the code and install `crypto-browserify`.

**CRA**
`globalThis.crypto` well defined
BUT at startup webpack still complains about `crypto` import...
Hence adding `/* webpackIgnore: true */`

**Vite.js**
No problem

**Node 18**
No problem

**Node 20**
No problem