### PR TITLE
Feature/custom errors for api calls

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,6 +16,14 @@ steps:
     commands:
       - node test/scripts/prepare-test-env.js
 
+  - name: server-error-500
+    image: nginx:alpine
+    expose:
+      - 80
+    commands:
+      - cp test/mock/server/http500.nginx.conf /etc/nginx/conf.d/default.conf
+      - nginx
+
   - name: bellecour-fork
     detach: true
     image: ghcr.io/foundry-rs/foundry:v1.0.0

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,14 +16,15 @@ steps:
     commands:
       - node test/scripts/prepare-test-env.js
 
-  - name: server-error-500
+  - name: service-internal-error
     detach: true
     image: nginx:alpine
+    pull: always
     expose:
       - 80
     commands:
       - cp test/mock/server/http500.nginx.conf /etc/nginx/conf.d/default.conf
-      - nginx
+      - nginx -g "daemon off;"
 
   - name: bellecour-fork
     detach: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,6 +22,7 @@ steps:
       - 80
     commands:
       - cp test/mock/server/http500.nginx.conf /etc/nginx/conf.d/default.conf
+      - cat /etc/nginx/conf.d/default.conf
       - nginx
 
   - name: bellecour-fork

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,12 +17,12 @@ steps:
       - node test/scripts/prepare-test-env.js
 
   - name: server-error-500
+    detach: true
     image: nginx:alpine
     expose:
       - 80
     commands:
       - cp test/mock/server/http500.nginx.conf /etc/nginx/conf.d/default.conf
-      - cat /etc/nginx/conf.d/default.conf
       - nginx
 
   - name: bellecour-fork

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## Next
+
+### Added
+
+- a generic `ApiCallError` is thrown when a network error occurs while connecting to a service or when the service returns a HTTP 5xx status code, each service has a dedicated inherited error class
+  - `SmsCallError` for SMS call errors
+  - `ResultProxyCallError` for Result Proxy call errors
+  - `MarketCallError` for Market API call errors
+  - `IpfsGatewayCallError` for IPFS gateway call errors
+  - `WorkerpoolCallError` for workerpool API call errors
+- Error `cause` is now set in errors everywhere `originalError` was used
+
+### Changed
+
+- [DEPRECATED] `originalError` is deprecated in favor of Error `cause`
+
 ## [8.8.0] 2024-05-28
 
 ### Changed

--- a/docs/classes/errors.ApiCallError.md
+++ b/docs/classes/errors.ApiCallError.md
@@ -30,6 +30,7 @@ ApiCallError encapsulate an error occurring during a call to an API such as a ne
 
 ### Properties
 
+- [cause](errors.ApiCallError.md#cause)
 - [originalError](errors.ApiCallError.md#originalerror)
 
 ## Constructors
@@ -55,6 +56,16 @@ Error.constructor
 
 ## Properties
 
+### cause
+
+• `Optional` **cause**: `Error`
+
+___
+
 ### originalError
 
 • `Optional` **originalError**: `Error`
+
+**`Deprecated`**
+
+use Error cause instead

--- a/docs/classes/errors.ApiCallError.md
+++ b/docs/classes/errors.ApiCallError.md
@@ -4,7 +4,7 @@
 
 [errors](../modules/errors.md).ApiCallError
 
-ApiCallError encapsulate an error occurring during a call to an API such as a network error or a server internal error.
+ApiCallError encapsulates an error occurring during a call to an API such as a network error or a server-side internal error.
 
 ## Hierarchy
 
@@ -41,10 +41,10 @@ ApiCallError encapsulate an error occurring during a call to an API such as a ne
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `message` | `string` |
-| `originalError` | `Error` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | `string` | A descriptive error message detailing the nature of the error. |
+| `originalError` | `Error` | The original Error object that caused this API call error. |
 
 #### Returns
 
@@ -58,14 +58,16 @@ Error.constructor
 
 ### cause
 
-• `Optional` **cause**: `Error`
+• **cause**: `Error`
+
+The original Error object that caused this API call error.
 
 ___
 
 ### originalError
 
-• `Optional` **originalError**: `Error`
+• **originalError**: `Error`
 
 **`Deprecated`**
 
-use Error cause instead
+use Error cause instead.

--- a/docs/classes/errors.ApiCallError.md
+++ b/docs/classes/errors.ApiCallError.md
@@ -1,0 +1,60 @@
+[iexec](../README.md) / [Exports](../modules.md) / [errors](../modules/errors.md) / ApiCallError
+
+# Class: ApiCallError
+
+[errors](../modules/errors.md).ApiCallError
+
+ApiCallError encapsulate an error occurring during a call to an API such as a network error or a server internal error.
+
+## Hierarchy
+
+- `Error`
+
+  ↳ **`ApiCallError`**
+
+  ↳↳ [`SmsCallError`](errors.SmsCallError.md)
+
+  ↳↳ [`ResultProxyCallError`](errors.ResultProxyCallError.md)
+
+  ↳↳ [`MarketCallError`](errors.MarketCallError.md)
+
+  ↳↳ [`IpfsGatewayCallError`](errors.IpfsGatewayCallError.md)
+
+  ↳↳ [`WorkerpoolCallError`](errors.WorkerpoolCallError.md)
+
+## Table of contents
+
+### Constructors
+
+- [constructor](errors.ApiCallError.md#constructor)
+
+### Properties
+
+- [originalError](errors.ApiCallError.md#originalerror)
+
+## Constructors
+
+### constructor
+
+• **new ApiCallError**(`message`, `originalError`): [`ApiCallError`](errors.ApiCallError.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | `string` |
+| `originalError` | `Error` |
+
+#### Returns
+
+[`ApiCallError`](errors.ApiCallError.md)
+
+#### Overrides
+
+Error.constructor
+
+## Properties
+
+### originalError
+
+• `Optional` **originalError**: `Error`

--- a/docs/classes/errors.BridgeError.md
+++ b/docs/classes/errors.BridgeError.md
@@ -28,19 +28,20 @@ BridgeError is thrown when bridging RLC between mainchain and sidechain fail bef
 
 ### constructor
 
-• **new BridgeError**(`message?`): [`BridgeError`](errors.BridgeError.md)
+• **new BridgeError**(`originalError`, `sendTxHash`): [`BridgeError`](errors.BridgeError.md)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `message?` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `originalError` | `Error` | The original Error object that caused this API call error. |
+| `sendTxHash` | `string` | Hash of the transaction sending the value to the bridge contract. |
 
 #### Returns
 
 [`BridgeError`](errors.BridgeError.md)
 
-#### Inherited from
+#### Overrides
 
 Error.constructor
 
@@ -48,13 +49,15 @@ Error.constructor
 
 ### cause
 
-• `Optional` **cause**: `Error`
+• **cause**: `Error`
+
+The original Error object that caused this API call error.
 
 ___
 
 ### originalError
 
-• `Optional` **originalError**: `Error`
+• **originalError**: `Error`
 
 **`Deprecated`**
 
@@ -64,4 +67,6 @@ ___
 
 ### sendTxHash
 
-• `Optional` **sendTxHash**: `string`
+• **sendTxHash**: `string`
+
+Hash of the transaction sending the value to the bridge contract.

--- a/docs/classes/errors.BridgeError.md
+++ b/docs/classes/errors.BridgeError.md
@@ -20,6 +20,7 @@ BridgeError is thrown when bridging RLC between mainchain and sidechain fail bef
 
 ### Properties
 
+- [cause](errors.BridgeError.md#cause)
 - [originalError](errors.BridgeError.md#originalerror)
 - [sendTxHash](errors.BridgeError.md#sendtxhash)
 
@@ -45,9 +46,19 @@ Error.constructor
 
 ## Properties
 
+### cause
+
+• `Optional` **cause**: `Error`
+
+___
+
 ### originalError
 
 • `Optional` **originalError**: `Error`
+
+**`Deprecated`**
+
+use Error cause instead
 
 ___
 

--- a/docs/classes/errors.IpfsGatewayCallError.md
+++ b/docs/classes/errors.IpfsGatewayCallError.md
@@ -4,7 +4,7 @@
 
 [errors](../modules/errors.md).IpfsGatewayCallError
 
-IpfsGatewayCallError encapsulate an error occurring during a call to the IPFS gateway API such as a network error or a server internal error.
+IpfsGatewayCallError encapsulates an error occurring during a call to the IPFS gateway API such as a network error or a server-side internal error.
 
 ## Hierarchy
 
@@ -31,10 +31,10 @@ IpfsGatewayCallError encapsulate an error occurring during a call to the IPFS ga
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `message` | `string` |
-| `originalError` | `Error` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | `string` | A descriptive error message detailing the nature of the error. |
+| `originalError` | `Error` | The original Error object that caused this API call error. |
 
 #### Returns
 
@@ -48,7 +48,9 @@ IpfsGatewayCallError encapsulate an error occurring during a call to the IPFS ga
 
 ### cause
 
-• `Optional` **cause**: `Error`
+• **cause**: `Error`
+
+The original Error object that caused this API call error.
 
 #### Inherited from
 
@@ -58,11 +60,11 @@ ___
 
 ### originalError
 
-• `Optional` **originalError**: `Error`
+• **originalError**: `Error`
 
 **`Deprecated`**
 
-use Error cause instead
+use Error cause instead.
 
 #### Inherited from
 

--- a/docs/classes/errors.IpfsGatewayCallError.md
+++ b/docs/classes/errors.IpfsGatewayCallError.md
@@ -1,0 +1,54 @@
+[iexec](../README.md) / [Exports](../modules.md) / [errors](../modules/errors.md) / IpfsGatewayCallError
+
+# Class: IpfsGatewayCallError
+
+[errors](../modules/errors.md).IpfsGatewayCallError
+
+IpfsGatewayCallError encapsulate an error occurring during a call to the IPFS gateway API such as a network error or a server internal error.
+
+## Hierarchy
+
+- [`ApiCallError`](errors.ApiCallError.md)
+
+  ↳ **`IpfsGatewayCallError`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](errors.IpfsGatewayCallError.md#constructor)
+
+### Properties
+
+- [originalError](errors.IpfsGatewayCallError.md#originalerror)
+
+## Constructors
+
+### constructor
+
+• **new IpfsGatewayCallError**(`message`, `originalError`): [`IpfsGatewayCallError`](errors.IpfsGatewayCallError.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | `string` |
+| `originalError` | `Error` |
+
+#### Returns
+
+[`IpfsGatewayCallError`](errors.IpfsGatewayCallError.md)
+
+#### Inherited from
+
+[ApiCallError](errors.ApiCallError.md).[constructor](errors.ApiCallError.md#constructor)
+
+## Properties
+
+### originalError
+
+• `Optional` **originalError**: `Error`
+
+#### Inherited from
+
+[ApiCallError](errors.ApiCallError.md).[originalError](errors.ApiCallError.md#originalerror)

--- a/docs/classes/errors.IpfsGatewayCallError.md
+++ b/docs/classes/errors.IpfsGatewayCallError.md
@@ -20,6 +20,7 @@ IpfsGatewayCallError encapsulate an error occurring during a call to the IPFS ga
 
 ### Properties
 
+- [cause](errors.IpfsGatewayCallError.md#cause)
 - [originalError](errors.IpfsGatewayCallError.md#originalerror)
 
 ## Constructors
@@ -45,9 +46,23 @@ IpfsGatewayCallError encapsulate an error occurring during a call to the IPFS ga
 
 ## Properties
 
+### cause
+
+• `Optional` **cause**: `Error`
+
+#### Inherited from
+
+[ApiCallError](errors.ApiCallError.md).[cause](errors.ApiCallError.md#cause)
+
+___
+
 ### originalError
 
 • `Optional` **originalError**: `Error`
+
+**`Deprecated`**
+
+use Error cause instead
 
 #### Inherited from
 

--- a/docs/classes/errors.MarketCallError.md
+++ b/docs/classes/errors.MarketCallError.md
@@ -20,6 +20,7 @@ MarketCallError encapsulate an error occurring during a call to the Market API s
 
 ### Properties
 
+- [cause](errors.MarketCallError.md#cause)
 - [originalError](errors.MarketCallError.md#originalerror)
 
 ## Constructors
@@ -45,9 +46,23 @@ MarketCallError encapsulate an error occurring during a call to the Market API s
 
 ## Properties
 
+### cause
+
+• `Optional` **cause**: `Error`
+
+#### Inherited from
+
+[ApiCallError](errors.ApiCallError.md).[cause](errors.ApiCallError.md#cause)
+
+___
+
 ### originalError
 
 • `Optional` **originalError**: `Error`
+
+**`Deprecated`**
+
+use Error cause instead
 
 #### Inherited from
 

--- a/docs/classes/errors.MarketCallError.md
+++ b/docs/classes/errors.MarketCallError.md
@@ -4,7 +4,7 @@
 
 [errors](../modules/errors.md).MarketCallError
 
-MarketCallError encapsulate an error occurring during a call to the Market API such as a network error or a server internal error.
+MarketCallError encapsulates an error occurring during a call to the Market API such as a network error or a server-side internal error.
 
 ## Hierarchy
 
@@ -31,10 +31,10 @@ MarketCallError encapsulate an error occurring during a call to the Market API s
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `message` | `string` |
-| `originalError` | `Error` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | `string` | A descriptive error message detailing the nature of the error. |
+| `originalError` | `Error` | The original Error object that caused this API call error. |
 
 #### Returns
 
@@ -48,7 +48,9 @@ MarketCallError encapsulate an error occurring during a call to the Market API s
 
 ### cause
 
-• `Optional` **cause**: `Error`
+• **cause**: `Error`
+
+The original Error object that caused this API call error.
 
 #### Inherited from
 
@@ -58,11 +60,11 @@ ___
 
 ### originalError
 
-• `Optional` **originalError**: `Error`
+• **originalError**: `Error`
 
 **`Deprecated`**
 
-use Error cause instead
+use Error cause instead.
 
 #### Inherited from
 

--- a/docs/classes/errors.MarketCallError.md
+++ b/docs/classes/errors.MarketCallError.md
@@ -1,0 +1,54 @@
+[iexec](../README.md) / [Exports](../modules.md) / [errors](../modules/errors.md) / MarketCallError
+
+# Class: MarketCallError
+
+[errors](../modules/errors.md).MarketCallError
+
+MarketCallError encapsulate an error occurring during a call to the Market API such as a network error or a server internal error.
+
+## Hierarchy
+
+- [`ApiCallError`](errors.ApiCallError.md)
+
+  ↳ **`MarketCallError`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](errors.MarketCallError.md#constructor)
+
+### Properties
+
+- [originalError](errors.MarketCallError.md#originalerror)
+
+## Constructors
+
+### constructor
+
+• **new MarketCallError**(`message`, `originalError`): [`MarketCallError`](errors.MarketCallError.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | `string` |
+| `originalError` | `Error` |
+
+#### Returns
+
+[`MarketCallError`](errors.MarketCallError.md)
+
+#### Inherited from
+
+[ApiCallError](errors.ApiCallError.md).[constructor](errors.ApiCallError.md#constructor)
+
+## Properties
+
+### originalError
+
+• `Optional` **originalError**: `Error`
+
+#### Inherited from
+
+[ApiCallError](errors.ApiCallError.md).[originalError](errors.ApiCallError.md#originalerror)

--- a/docs/classes/errors.ObjectNotFoundError.md
+++ b/docs/classes/errors.ObjectNotFoundError.md
@@ -4,7 +4,7 @@
 
 [errors](../modules/errors.md).ObjectNotFoundError
 
-ObjectNotFoundError is thrown when trying to access an unknown resource.
+ObjectNotFoundError is thrown when trying to access an unknown onchain resource.
 
 ## Hierarchy
 
@@ -32,11 +32,11 @@ ObjectNotFoundError is thrown when trying to access an unknown resource.
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `objName` | `string` |
-| `objId` | `string` |
-| `chainId` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `objName` | `string` | Name of the resource. |
+| `objId` | `string` | Id or address of the resource. |
+| `chainId` | `string` | Chain id of the blockchain. |
 
 #### Returns
 
@@ -50,16 +50,22 @@ Error.constructor
 
 ### chainId
 
-• `Optional` **chainId**: `string`
+• **chainId**: `string`
+
+Chain id of the blockchain.
 
 ___
 
 ### objId
 
-• `Optional` **objId**: `string`
+• **objId**: `string`
+
+Id or address of the resource.
 
 ___
 
 ### objName
 
-• `Optional` **objName**: `string`
+• **objName**: `string`
+
+Name of the resource.

--- a/docs/classes/errors.ResultProxyCallError.md
+++ b/docs/classes/errors.ResultProxyCallError.md
@@ -1,0 +1,54 @@
+[iexec](../README.md) / [Exports](../modules.md) / [errors](../modules/errors.md) / ResultProxyCallError
+
+# Class: ResultProxyCallError
+
+[errors](../modules/errors.md).ResultProxyCallError
+
+ResultProxyCallError encapsulate an error occurring during a call to the Result-Proxy API such as a network error or a server internal error.
+
+## Hierarchy
+
+- [`ApiCallError`](errors.ApiCallError.md)
+
+  ↳ **`ResultProxyCallError`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](errors.ResultProxyCallError.md#constructor)
+
+### Properties
+
+- [originalError](errors.ResultProxyCallError.md#originalerror)
+
+## Constructors
+
+### constructor
+
+• **new ResultProxyCallError**(`message`, `originalError`): [`ResultProxyCallError`](errors.ResultProxyCallError.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | `string` |
+| `originalError` | `Error` |
+
+#### Returns
+
+[`ResultProxyCallError`](errors.ResultProxyCallError.md)
+
+#### Inherited from
+
+[ApiCallError](errors.ApiCallError.md).[constructor](errors.ApiCallError.md#constructor)
+
+## Properties
+
+### originalError
+
+• `Optional` **originalError**: `Error`
+
+#### Inherited from
+
+[ApiCallError](errors.ApiCallError.md).[originalError](errors.ApiCallError.md#originalerror)

--- a/docs/classes/errors.ResultProxyCallError.md
+++ b/docs/classes/errors.ResultProxyCallError.md
@@ -4,7 +4,7 @@
 
 [errors](../modules/errors.md).ResultProxyCallError
 
-ResultProxyCallError encapsulate an error occurring during a call to the Result Proxy API such as a network error or a server internal error.
+ResultProxyCallError encapsulates an error occurring during a call to the Result Proxy API such as a network error or a server-side internal error.
 
 ## Hierarchy
 
@@ -31,10 +31,10 @@ ResultProxyCallError encapsulate an error occurring during a call to the Result 
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `message` | `string` |
-| `originalError` | `Error` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | `string` | A descriptive error message detailing the nature of the error. |
+| `originalError` | `Error` | The original Error object that caused this API call error. |
 
 #### Returns
 
@@ -48,7 +48,9 @@ ResultProxyCallError encapsulate an error occurring during a call to the Result 
 
 ### cause
 
-• `Optional` **cause**: `Error`
+• **cause**: `Error`
+
+The original Error object that caused this API call error.
 
 #### Inherited from
 
@@ -58,11 +60,11 @@ ___
 
 ### originalError
 
-• `Optional` **originalError**: `Error`
+• **originalError**: `Error`
 
 **`Deprecated`**
 
-use Error cause instead
+use Error cause instead.
 
 #### Inherited from
 

--- a/docs/classes/errors.ResultProxyCallError.md
+++ b/docs/classes/errors.ResultProxyCallError.md
@@ -20,6 +20,7 @@ ResultProxyCallError encapsulate an error occurring during a call to the Result-
 
 ### Properties
 
+- [cause](errors.ResultProxyCallError.md#cause)
 - [originalError](errors.ResultProxyCallError.md#originalerror)
 
 ## Constructors
@@ -45,9 +46,23 @@ ResultProxyCallError encapsulate an error occurring during a call to the Result-
 
 ## Properties
 
+### cause
+
+• `Optional` **cause**: `Error`
+
+#### Inherited from
+
+[ApiCallError](errors.ApiCallError.md).[cause](errors.ApiCallError.md#cause)
+
+___
+
 ### originalError
 
 • `Optional` **originalError**: `Error`
+
+**`Deprecated`**
+
+use Error cause instead
 
 #### Inherited from
 

--- a/docs/classes/errors.ResultProxyCallError.md
+++ b/docs/classes/errors.ResultProxyCallError.md
@@ -4,7 +4,7 @@
 
 [errors](../modules/errors.md).ResultProxyCallError
 
-ResultProxyCallError encapsulate an error occurring during a call to the Result-Proxy API such as a network error or a server internal error.
+ResultProxyCallError encapsulate an error occurring during a call to the Result Proxy API such as a network error or a server internal error.
 
 ## Hierarchy
 

--- a/docs/classes/errors.SmsCallError.md
+++ b/docs/classes/errors.SmsCallError.md
@@ -1,0 +1,54 @@
+[iexec](../README.md) / [Exports](../modules.md) / [errors](../modules/errors.md) / SmsCallError
+
+# Class: SmsCallError
+
+[errors](../modules/errors.md).SmsCallError
+
+SmsCallError encapsulate an error occurring during a call to the SMS API such as a network error or a server internal error.
+
+## Hierarchy
+
+- [`ApiCallError`](errors.ApiCallError.md)
+
+  ↳ **`SmsCallError`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](errors.SmsCallError.md#constructor)
+
+### Properties
+
+- [originalError](errors.SmsCallError.md#originalerror)
+
+## Constructors
+
+### constructor
+
+• **new SmsCallError**(`message`, `originalError`): [`SmsCallError`](errors.SmsCallError.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | `string` |
+| `originalError` | `Error` |
+
+#### Returns
+
+[`SmsCallError`](errors.SmsCallError.md)
+
+#### Inherited from
+
+[ApiCallError](errors.ApiCallError.md).[constructor](errors.ApiCallError.md#constructor)
+
+## Properties
+
+### originalError
+
+• `Optional` **originalError**: `Error`
+
+#### Inherited from
+
+[ApiCallError](errors.ApiCallError.md).[originalError](errors.ApiCallError.md#originalerror)

--- a/docs/classes/errors.SmsCallError.md
+++ b/docs/classes/errors.SmsCallError.md
@@ -4,7 +4,7 @@
 
 [errors](../modules/errors.md).SmsCallError
 
-SmsCallError encapsulate an error occurring during a call to the SMS API such as a network error or a server internal error.
+SmsCallError encapsulates an error occurring during a call to the SMS API such as a network error or a server-side internal error.
 
 ## Hierarchy
 
@@ -31,10 +31,10 @@ SmsCallError encapsulate an error occurring during a call to the SMS API such as
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `message` | `string` |
-| `originalError` | `Error` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | `string` | A descriptive error message detailing the nature of the error. |
+| `originalError` | `Error` | The original Error object that caused this API call error. |
 
 #### Returns
 
@@ -48,7 +48,9 @@ SmsCallError encapsulate an error occurring during a call to the SMS API such as
 
 ### cause
 
-• `Optional` **cause**: `Error`
+• **cause**: `Error`
+
+The original Error object that caused this API call error.
 
 #### Inherited from
 
@@ -58,11 +60,11 @@ ___
 
 ### originalError
 
-• `Optional` **originalError**: `Error`
+• **originalError**: `Error`
 
 **`Deprecated`**
 
-use Error cause instead
+use Error cause instead.
 
 #### Inherited from
 

--- a/docs/classes/errors.SmsCallError.md
+++ b/docs/classes/errors.SmsCallError.md
@@ -20,6 +20,7 @@ SmsCallError encapsulate an error occurring during a call to the SMS API such as
 
 ### Properties
 
+- [cause](errors.SmsCallError.md#cause)
 - [originalError](errors.SmsCallError.md#originalerror)
 
 ## Constructors
@@ -45,9 +46,23 @@ SmsCallError encapsulate an error occurring during a call to the SMS API such as
 
 ## Properties
 
+### cause
+
+• `Optional` **cause**: `Error`
+
+#### Inherited from
+
+[ApiCallError](errors.ApiCallError.md).[cause](errors.ApiCallError.md#cause)
+
+___
+
 ### originalError
 
 • `Optional` **originalError**: `Error`
+
+**`Deprecated`**
+
+use Error cause instead
 
 #### Inherited from
 

--- a/docs/classes/errors.Web3ProviderCallError.md
+++ b/docs/classes/errors.Web3ProviderCallError.md
@@ -20,6 +20,7 @@ Web3ProviderCallError encapsulate an error thrown by the web3 provider during a 
 
 ### Properties
 
+- [cause](errors.Web3ProviderCallError.md#cause)
 - [originalError](errors.Web3ProviderCallError.md#originalerror)
 
 ## Constructors
@@ -45,9 +46,23 @@ Web3ProviderCallError encapsulate an error thrown by the web3 provider during a 
 
 ## Properties
 
+### cause
+
+• `Optional` **cause**: `Error`
+
+#### Inherited from
+
+[Web3ProviderError](errors.Web3ProviderError.md).[cause](errors.Web3ProviderError.md#cause)
+
+___
+
 ### originalError
 
 • `Optional` **originalError**: `Error`
+
+**`Deprecated`**
+
+use Error cause instead
 
 #### Inherited from
 

--- a/docs/classes/errors.Web3ProviderCallError.md
+++ b/docs/classes/errors.Web3ProviderCallError.md
@@ -4,7 +4,7 @@
 
 [errors](../modules/errors.md).Web3ProviderCallError
 
-Web3ProviderCallError encapsulate an error thrown by the web3 provider during a web3 call.
+Web3ProviderCallError encapsulates an error thrown by the web3 provider during a web3 call.
 
 ## Hierarchy
 
@@ -31,10 +31,10 @@ Web3ProviderCallError encapsulate an error thrown by the web3 provider during a 
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `message` | `string` |
-| `originalError` | `Error` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | `string` | A descriptive error message detailing the nature of the error. |
+| `originalError` | `Error` | The original Error object that caused this web3 provider error. |
 
 #### Returns
 
@@ -48,7 +48,9 @@ Web3ProviderCallError encapsulate an error thrown by the web3 provider during a 
 
 ### cause
 
-• `Optional` **cause**: `Error`
+• **cause**: `Error`
+
+The original Error object that caused this web3 provider error.
 
 #### Inherited from
 
@@ -58,11 +60,11 @@ ___
 
 ### originalError
 
-• `Optional` **originalError**: `Error`
+• **originalError**: `Error`
 
 **`Deprecated`**
 
-use Error cause instead
+use Error cause instead.
 
 #### Inherited from
 

--- a/docs/classes/errors.Web3ProviderError.md
+++ b/docs/classes/errors.Web3ProviderError.md
@@ -26,6 +26,7 @@ Web3ProviderError encapsulate an error thrown by the web3 provider.
 
 ### Properties
 
+- [cause](errors.Web3ProviderError.md#cause)
 - [originalError](errors.Web3ProviderError.md#originalerror)
 
 ## Constructors
@@ -51,6 +52,16 @@ Error.constructor
 
 ## Properties
 
+### cause
+
+• `Optional` **cause**: `Error`
+
+___
+
 ### originalError
 
 • `Optional` **originalError**: `Error`
+
+**`Deprecated`**
+
+use Error cause instead

--- a/docs/classes/errors.Web3ProviderError.md
+++ b/docs/classes/errors.Web3ProviderError.md
@@ -4,7 +4,7 @@
 
 [errors](../modules/errors.md).Web3ProviderError
 
-Web3ProviderError encapsulate an error thrown by the web3 provider.
+Web3ProviderError encapsulates an error thrown by the web3 provider.
 
 ## Hierarchy
 
@@ -37,10 +37,10 @@ Web3ProviderError encapsulate an error thrown by the web3 provider.
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `message` | `string` |
-| `originalError` | `Error` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | `string` | A descriptive error message detailing the nature of the error. |
+| `originalError` | `Error` | The original Error object that caused this web3 provider error. |
 
 #### Returns
 
@@ -54,14 +54,16 @@ Error.constructor
 
 ### cause
 
-• `Optional` **cause**: `Error`
+• **cause**: `Error`
+
+The original Error object that caused this web3 provider error.
 
 ___
 
 ### originalError
 
-• `Optional` **originalError**: `Error`
+• **originalError**: `Error`
 
 **`Deprecated`**
 
-use Error cause instead
+use Error cause instead.

--- a/docs/classes/errors.Web3ProviderSendError.md
+++ b/docs/classes/errors.Web3ProviderSendError.md
@@ -20,6 +20,7 @@ Web3ProviderSendError encapsulate an error thrown by the web3 provider during a 
 
 ### Properties
 
+- [cause](errors.Web3ProviderSendError.md#cause)
 - [originalError](errors.Web3ProviderSendError.md#originalerror)
 
 ## Constructors
@@ -45,9 +46,23 @@ Web3ProviderSendError encapsulate an error thrown by the web3 provider during a 
 
 ## Properties
 
+### cause
+
+• `Optional` **cause**: `Error`
+
+#### Inherited from
+
+[Web3ProviderError](errors.Web3ProviderError.md).[cause](errors.Web3ProviderError.md#cause)
+
+___
+
 ### originalError
 
 • `Optional` **originalError**: `Error`
+
+**`Deprecated`**
+
+use Error cause instead
 
 #### Inherited from
 

--- a/docs/classes/errors.Web3ProviderSendError.md
+++ b/docs/classes/errors.Web3ProviderSendError.md
@@ -4,7 +4,7 @@
 
 [errors](../modules/errors.md).Web3ProviderSendError
 
-Web3ProviderSendError encapsulate an error thrown by the web3 provider during a transaction.
+Web3ProviderSendError encapsulates an error thrown by the web3 provider during a transaction.
 
 ## Hierarchy
 
@@ -31,10 +31,10 @@ Web3ProviderSendError encapsulate an error thrown by the web3 provider during a 
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `message` | `string` |
-| `originalError` | `Error` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | `string` | A descriptive error message detailing the nature of the error. |
+| `originalError` | `Error` | The original Error object that caused this web3 provider error. |
 
 #### Returns
 
@@ -48,7 +48,9 @@ Web3ProviderSendError encapsulate an error thrown by the web3 provider during a 
 
 ### cause
 
-• `Optional` **cause**: `Error`
+• **cause**: `Error`
+
+The original Error object that caused this web3 provider error.
 
 #### Inherited from
 
@@ -58,11 +60,11 @@ ___
 
 ### originalError
 
-• `Optional` **originalError**: `Error`
+• **originalError**: `Error`
 
 **`Deprecated`**
 
-use Error cause instead
+use Error cause instead.
 
 #### Inherited from
 

--- a/docs/classes/errors.Web3ProviderSignMessageError.md
+++ b/docs/classes/errors.Web3ProviderSignMessageError.md
@@ -4,7 +4,7 @@
 
 [errors](../modules/errors.md).Web3ProviderSignMessageError
 
-Web3ProviderSignMessageError encapsulate an error thrown by the web3 provider during a message signature.
+Web3ProviderSignMessageError encapsulates an error thrown by the web3 provider during a message signature.
 
 ## Hierarchy
 
@@ -31,10 +31,10 @@ Web3ProviderSignMessageError encapsulate an error thrown by the web3 provider du
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `message` | `string` |
-| `originalError` | `Error` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | `string` | A descriptive error message detailing the nature of the error. |
+| `originalError` | `Error` | The original Error object that caused this web3 provider error. |
 
 #### Returns
 
@@ -48,7 +48,9 @@ Web3ProviderSignMessageError encapsulate an error thrown by the web3 provider du
 
 ### cause
 
-• `Optional` **cause**: `Error`
+• **cause**: `Error`
+
+The original Error object that caused this web3 provider error.
 
 #### Inherited from
 
@@ -58,11 +60,11 @@ ___
 
 ### originalError
 
-• `Optional` **originalError**: `Error`
+• **originalError**: `Error`
 
 **`Deprecated`**
 
-use Error cause instead
+use Error cause instead.
 
 #### Inherited from
 

--- a/docs/classes/errors.Web3ProviderSignMessageError.md
+++ b/docs/classes/errors.Web3ProviderSignMessageError.md
@@ -20,6 +20,7 @@ Web3ProviderSignMessageError encapsulate an error thrown by the web3 provider du
 
 ### Properties
 
+- [cause](errors.Web3ProviderSignMessageError.md#cause)
 - [originalError](errors.Web3ProviderSignMessageError.md#originalerror)
 
 ## Constructors
@@ -45,9 +46,23 @@ Web3ProviderSignMessageError encapsulate an error thrown by the web3 provider du
 
 ## Properties
 
+### cause
+
+• `Optional` **cause**: `Error`
+
+#### Inherited from
+
+[Web3ProviderError](errors.Web3ProviderError.md).[cause](errors.Web3ProviderError.md#cause)
+
+___
+
 ### originalError
 
 • `Optional` **originalError**: `Error`
+
+**`Deprecated`**
+
+use Error cause instead
 
 #### Inherited from
 

--- a/docs/classes/errors.WorkerpoolCallError.md
+++ b/docs/classes/errors.WorkerpoolCallError.md
@@ -20,6 +20,7 @@ WorkerpoolCallError encapsulate an error occurring during a call to a workerpool
 
 ### Properties
 
+- [cause](errors.WorkerpoolCallError.md#cause)
 - [originalError](errors.WorkerpoolCallError.md#originalerror)
 
 ## Constructors
@@ -45,9 +46,23 @@ WorkerpoolCallError encapsulate an error occurring during a call to a workerpool
 
 ## Properties
 
+### cause
+
+• `Optional` **cause**: `Error`
+
+#### Inherited from
+
+[ApiCallError](errors.ApiCallError.md).[cause](errors.ApiCallError.md#cause)
+
+___
+
 ### originalError
 
 • `Optional` **originalError**: `Error`
+
+**`Deprecated`**
+
+use Error cause instead
 
 #### Inherited from
 

--- a/docs/classes/errors.WorkerpoolCallError.md
+++ b/docs/classes/errors.WorkerpoolCallError.md
@@ -4,7 +4,7 @@
 
 [errors](../modules/errors.md).WorkerpoolCallError
 
-WorkerpoolCallError encapsulate an error occurring during a call to a workerpool API such as a network error or a server internal error.
+WorkerpoolCallError encapsulates an error occurring during a call to a workerpool API such as a network error or a server-side internal error.
 
 ## Hierarchy
 
@@ -31,10 +31,10 @@ WorkerpoolCallError encapsulate an error occurring during a call to a workerpool
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `message` | `string` |
-| `originalError` | `Error` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | `string` | A descriptive error message detailing the nature of the error. |
+| `originalError` | `Error` | The original Error object that caused this API call error. |
 
 #### Returns
 
@@ -48,7 +48,9 @@ WorkerpoolCallError encapsulate an error occurring during a call to a workerpool
 
 ### cause
 
-• `Optional` **cause**: `Error`
+• **cause**: `Error`
+
+The original Error object that caused this API call error.
 
 #### Inherited from
 
@@ -58,11 +60,11 @@ ___
 
 ### originalError
 
-• `Optional` **originalError**: `Error`
+• **originalError**: `Error`
 
 **`Deprecated`**
 
-use Error cause instead
+use Error cause instead.
 
 #### Inherited from
 

--- a/docs/classes/errors.WorkerpoolCallError.md
+++ b/docs/classes/errors.WorkerpoolCallError.md
@@ -1,0 +1,54 @@
+[iexec](../README.md) / [Exports](../modules.md) / [errors](../modules/errors.md) / WorkerpoolCallError
+
+# Class: WorkerpoolCallError
+
+[errors](../modules/errors.md).WorkerpoolCallError
+
+WorkerpoolCallError encapsulate an error occurring during a call to a workerpool API such as a network error or a server internal error.
+
+## Hierarchy
+
+- [`ApiCallError`](errors.ApiCallError.md)
+
+  ↳ **`WorkerpoolCallError`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](errors.WorkerpoolCallError.md#constructor)
+
+### Properties
+
+- [originalError](errors.WorkerpoolCallError.md#originalerror)
+
+## Constructors
+
+### constructor
+
+• **new WorkerpoolCallError**(`message`, `originalError`): [`WorkerpoolCallError`](errors.WorkerpoolCallError.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | `string` |
+| `originalError` | `Error` |
+
+#### Returns
+
+[`WorkerpoolCallError`](errors.WorkerpoolCallError.md)
+
+#### Inherited from
+
+[ApiCallError](errors.ApiCallError.md).[constructor](errors.ApiCallError.md#constructor)
+
+## Properties
+
+### originalError
+
+• `Optional` **originalError**: `Error`
+
+#### Inherited from
+
+[ApiCallError](errors.ApiCallError.md).[originalError](errors.ApiCallError.md#originalerror)

--- a/docs/modules/errors.md
+++ b/docs/modules/errors.md
@@ -6,11 +6,17 @@
 
 ### Classes
 
+- [ApiCallError](../classes/errors.ApiCallError.md)
 - [BridgeError](../classes/errors.BridgeError.md)
 - [ConfigurationError](../classes/errors.ConfigurationError.md)
+- [IpfsGatewayCallError](../classes/errors.IpfsGatewayCallError.md)
+- [MarketCallError](../classes/errors.MarketCallError.md)
 - [ObjectNotFoundError](../classes/errors.ObjectNotFoundError.md)
+- [ResultProxyCallError](../classes/errors.ResultProxyCallError.md)
+- [SmsCallError](../classes/errors.SmsCallError.md)
 - [ValidationError](../classes/errors.ValidationError.md)
 - [Web3ProviderCallError](../classes/errors.Web3ProviderCallError.md)
 - [Web3ProviderError](../classes/errors.Web3ProviderError.md)
 - [Web3ProviderSendError](../classes/errors.Web3ProviderSendError.md)
 - [Web3ProviderSignMessageError](../classes/errors.Web3ProviderSignMessageError.md)
+- [WorkerpoolCallError](../classes/errors.WorkerpoolCallError.md)

--- a/src/common/execution/deal.js
+++ b/src/common/execution/deal.js
@@ -23,6 +23,7 @@ import {
 import { viewDeal, viewTask } from './common.js';
 import { obsTask } from './task.js';
 import { Observable, SafeObserver } from '../utils/reactive.js';
+import { MarketCallError } from '../utils/errors.js';
 
 const debug = Debug('iexec:execution:deal');
 
@@ -85,6 +86,7 @@ export const fetchRequesterDeals = async (
       api: iexecGatewayURL,
       endpoint: '/deals',
       query,
+      ApiCallErrorClass: MarketCallError,
     });
     if (response.ok && response.deals) {
       return response;
@@ -394,6 +396,7 @@ export const fetchDealsByOrderHash = async (
       api: iexecGatewayURL,
       endpoint: '/deals',
       query,
+      ApiCallErrorClass: MarketCallError,
     });
     if (response.ok && response.deals) {
       return { count: response.count, deals: response.deals };

--- a/src/common/execution/result.js
+++ b/src/common/execution/result.js
@@ -2,6 +2,7 @@ import Debug from 'debug';
 import { show } from './task.js';
 import { downloadZipApi } from '../utils/api-utils.js';
 import { bytes32Schema, throwIfMissing } from '../utils/validator.js';
+import { IpfsGatewayCallError } from '../utils/errors.js';
 
 const debug = Debug('iexec:execution:result');
 
@@ -13,8 +14,12 @@ const downloadFromIpfs = async (
     return await downloadZipApi.get({
       api: ipfsGatewayURL,
       endpoint: ipfsAddress,
+      ApiCallErrorClass: IpfsGatewayCallError,
     });
   } catch (error) {
+    if (error instanceof IpfsGatewayCallError) {
+      throw error;
+    }
     throw Error(`Failed to download from ${ipfsGatewayURL}: ${error.message}`);
   }
 };

--- a/src/common/market/orderbook.js
+++ b/src/common/market/orderbook.js
@@ -11,6 +11,7 @@ import {
   throwIfMissing,
   booleanSchema,
 } from '../utils/validator.js';
+import { MarketCallError } from '../utils/errors.js';
 
 const debug = Debug('iexec:market:orderbook');
 
@@ -81,6 +82,7 @@ export const fetchAppOrderbook = async (
       api: iexecGatewayURL,
       endpoint: '/apporders',
       query,
+      ApiCallErrorClass: MarketCallError,
     });
     if (ok) {
       return response;
@@ -120,7 +122,7 @@ export const fetchDatasetOrderbook = async (
         app: await addressOrAnySchema({
           ethProvider: contracts.provider,
         }).validate(app),
-      isAppStrict: await booleanSchema().validate(isAppStrict),
+        isAppStrict: await booleanSchema().validate(isAppStrict),
       }),
       ...(workerpool && {
         workerpool: await addressOrAnySchema({
@@ -157,6 +159,7 @@ export const fetchDatasetOrderbook = async (
       api: iexecGatewayURL,
       endpoint: '/datasetorders',
       query,
+      ApiCallErrorClass: MarketCallError,
     });
     if (ok) {
       return response;
@@ -247,6 +250,7 @@ export const fetchWorkerpoolOrderbook = async (
       api: iexecGatewayURL,
       endpoint: '/workerpoolorders',
       query,
+      ApiCallErrorClass: MarketCallError,
     });
     if (ok) {
       return response;
@@ -333,6 +337,7 @@ export const fetchRequestOrderbook = async (
       api: iexecGatewayURL,
       endpoint: '/requestorders',
       query,
+      ApiCallErrorClass: MarketCallError,
     });
     if (ok) {
       return response;

--- a/src/common/sms/check.js
+++ b/src/common/sms/check.js
@@ -5,6 +5,7 @@ import {
   throwIfMissing,
   positiveIntSchema,
 } from '../utils/validator.js';
+import { SmsCallError } from '../utils/errors.js';
 
 const debug = Debug('iexec:sms:check');
 
@@ -45,9 +46,7 @@ export const checkWeb3SecretExists = async (
       query: {
         secretAddress: vResourceAddress,
       },
-    }).catch((e) => {
-      debug(e);
-      throw Error(`SMS at ${smsURL} didn't answered`);
+      ApiCallErrorClass: SmsCallError,
     });
     if (res.ok) {
       cacheSecretExists({ smsURL, kindOfSecret, secretId });
@@ -89,9 +88,7 @@ export const checkWeb2SecretExists = async (
         ownerAddress: vOwnerAddress,
         secretName,
       },
-    }).catch((e) => {
-      debug(e);
-      throw Error(`SMS at ${smsURL} didn't answered`);
+      ApiCallErrorClass: SmsCallError,
     });
     if (res.ok) {
       cacheSecretExists({ smsURL, kindOfSecret, secretId });
@@ -128,9 +125,7 @@ export const checkRequesterSecretExists = async (
     const res = await httpRequest('HEAD')({
       api: smsURL,
       endpoint: `/requesters/${vRequesterAddress}/secrets/${secretName}`,
-    }).catch((e) => {
-      debug(e);
-      throw Error(`SMS at ${smsURL} didn't answered`);
+      ApiCallErrorClass: SmsCallError,
     });
     if (res.ok) {
       cacheSecretExists({ smsURL, kindOfSecret, secretId });
@@ -168,9 +163,7 @@ export const checkAppSecretExists = async (
     const res = await httpRequest('HEAD')({
       api: smsURL,
       endpoint: `/apps/${vAppAddress}/secrets/${vSecretIndex}`,
-    }).catch((e) => {
-      debug(e);
-      throw Error(`SMS at ${smsURL} didn't answered`);
+      ApiCallErrorClass: SmsCallError,
     });
     if (res.ok) {
       cacheSecretExists({ smsURL, kindOfSecret, secretId });

--- a/src/common/sms/push.js
+++ b/src/common/sms/push.js
@@ -12,6 +12,7 @@ import {
 import { wrapPersonalSign } from '../utils/errorWrappers.js';
 import { checkSigner } from '../utils/utils.js';
 import { checkWeb2SecretExists, checkRequesterSecretExists } from './check.js';
+import { SmsCallError } from '../utils/errors.js';
 
 const debug = Debug('iexec:sms');
 
@@ -93,9 +94,7 @@ export const pushWeb3Secret = async (
       headers: {
         Authorization: auth,
       },
-    }).catch((e) => {
-      debug(e);
-      throw Error(`SMS at ${smsURL} didn't answered`);
+      ApiCallErrorClass: SmsCallError,
     });
     return handleNonUpdatablePushSecret({
       response: res,
@@ -150,9 +149,7 @@ export const pushWeb2Secret = async (
       headers: {
         Authorization: auth,
       },
-    }).catch((e) => {
-      debug(e);
-      throw Error(`SMS at ${smsURL} didn't answered`);
+      ApiCallErrorClass: SmsCallError,
     });
     if (res.ok) {
       return {
@@ -207,9 +204,7 @@ export const pushRequesterSecret = async (
       headers: {
         Authorization: auth,
       },
-    }).catch((e) => {
-      debug(e);
-      throw Error(`SMS at ${smsURL} didn't answered`);
+      ApiCallErrorClass: SmsCallError,
     });
     if (res.ok) {
       return {
@@ -256,9 +251,7 @@ export const pushAppSecret = async (
       headers: {
         Authorization: auth,
       },
-    }).catch((e) => {
-      debug(e);
-      throw Error(`SMS at ${smsURL} didn't answered`);
+      ApiCallErrorClass: SmsCallError,
     });
     return handleNonUpdatablePushSecret({
       response: res,

--- a/src/common/utils/api-utils.js
+++ b/src/common/utils/api-utils.js
@@ -2,6 +2,7 @@ import Debug from 'debug';
 import querystring from 'query-string';
 import { hashEIP712 } from './sig-utils.js';
 import { wrapSignTypedData } from './errorWrappers.js';
+import { ApiCallError } from './errors.js';
 
 const debug = Debug('iexec:api-utils');
 
@@ -33,7 +34,14 @@ const makeHeaders = (method, headers, body) => {
 
 export const httpRequest =
   (method) =>
-  async ({ api, endpoint = '', query = {}, body = {}, headers = {} }) => {
+  async ({
+    api,
+    endpoint = '',
+    query = {},
+    body = {},
+    headers = {},
+    ApiCallErrorClass = ApiCallError,
+  }) => {
     debug(
       'httpRequest()',
       '\nmethod',
@@ -56,22 +64,26 @@ export const httpRequest =
       method,
       ...makeHeaders(method, headers, body),
       ...makeBody(method, body),
-    }).catch((error) => {
-      debug(`httpRequest() fetch:`, error);
-      throw Error(`Connection to ${baseURL} failed with a network error`);
-    });
+    })
+      .catch((error) => {
+        debug(`httpRequest() fetch:`, error);
+        throw new ApiCallErrorClass(
+          `Connection to ${baseURL} failed with a network error`,
+          error,
+        );
+      })
+      .then((response) => {
+        if (response.status >= 500 && response.status <= 599) {
+          throw new ApiCallErrorClass(
+            `Server at ${baseURL} encountered an internal error`,
+            Error(
+              `Server internal error: ${response.status} ${response.statusText}`,
+            ),
+          );
+        }
+        return response;
+      });
   };
-
-const checkResponseOk = (response) => {
-  if (!response.ok) {
-    throw Error(
-      `API call error: ${response.status} ${
-        response.statusText ? response.statusText : ''
-      }`,
-    );
-  }
-  return response;
-};
 
 const responseToJson = async (response) => {
   const contentType = response.headers.get('Content-Type');
@@ -84,18 +96,7 @@ const responseToJson = async (response) => {
       .then((json) => json && json.error)
       .catch(() => {});
     if (errorMessage) throw new Error(`API error: ${errorMessage}`);
-    throw Error(
-      `API error: ${response.status} ${
-        response.statusText ? response.statusText : ''
-      }`,
-    );
-  }
-  if (!response.ok) {
-    throw Error(
-      `API error: ${response.status} ${
-        response.statusText ? response.statusText : ''
-      }`,
-    );
+    throw Error(`API error: ${response.status} ${response.statusText}`);
   }
   throw new Error('The http response is not of JSON type');
 };
@@ -137,39 +138,54 @@ export const downloadZipApi = {
     httpRequest('GET')({
       ...args,
       ...{ headers: { Accept: 'application/zip', ...args.headers } },
-    }).then(checkResponseOk),
+    }).then((response) => {
+      if (!response.ok) {
+        throw Error(
+          `API error: ${response.status} ${
+            response.statusText ? response.statusText : ''
+          }`,
+        );
+      }
+      return response;
+    }),
 };
 
-export const getAuthorization =
-  (api, endpoint = '/challenge') =>
-  async (chainId, address, signer) => {
-    try {
-      const challenge = await jsonApi.get({
-        api,
-        endpoint,
-        query: {
-          chainId,
-          address,
-        },
-      });
-      const typedData = challenge.data || challenge;
-      const { domain, message } = typedData || {};
-      const { EIP712Domain, ...types } = typedData.types || {};
-      if (!domain || !types || !message) {
-        throw Error('Unexpected challenge format');
-      }
-      const sign = await wrapSignTypedData(
-        signer.signTypedData(domain, types, message),
-      );
-      const hash = hashEIP712(typedData);
-      const separator = '_';
-      return hash
-        .concat(separator)
-        .concat(sign)
-        .concat(separator)
-        .concat(address);
-    } catch (error) {
-      debug('getAuthorization()', error);
-      throw Error(`Failed to get authorization: ${error}`);
+export const getAuthorization = async ({
+  api,
+  endpoint,
+  ApiCallErrorClass,
+  chainId,
+  address,
+  signer,
+}) => {
+  const challenge = await jsonApi.get({
+    api,
+    endpoint,
+    query: {
+      chainId,
+      address,
+    },
+    ApiCallErrorClass,
+  });
+  try {
+    const typedData = challenge.data || challenge;
+    const { domain, message } = typedData || {};
+    const { EIP712Domain, ...types } = typedData.types || {};
+    if (!domain || !types || !message) {
+      throw Error('Unexpected challenge format');
     }
-  };
+    const sign = await wrapSignTypedData(
+      signer.signTypedData(domain, types, message),
+    );
+    const hash = hashEIP712(typedData);
+    const separator = '_';
+    return hash
+      .concat(separator)
+      .concat(sign)
+      .concat(separator)
+      .concat(address);
+  } catch (error) {
+    debug('getAuthorization()', error);
+    throw Error(`Failed to get authorization: ${error}`);
+  }
+};

--- a/src/common/utils/api-utils.js
+++ b/src/common/utils/api-utils.js
@@ -68,14 +68,14 @@ export const httpRequest =
       .catch((error) => {
         debug(`httpRequest() fetch:`, error);
         throw new ApiCallErrorClass(
-          `Connection to ${baseURL} failed with a network error`,
+          `Connection to ${api} failed with a network error`,
           error,
         );
       })
       .then((response) => {
         if (response.status >= 500 && response.status <= 599) {
           throw new ApiCallErrorClass(
-            `Server at ${baseURL} encountered an internal error`,
+            `Server at ${api} encountered an internal error`,
             Error(
               `Server internal error: ${response.status} ${response.statusText}`,
             ),

--- a/src/common/utils/errors.js
+++ b/src/common/utils/errors.js
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-identical-functions */
 export { ValidationError } from 'yup';
 
 const getPropsToCopy = (error) => {
@@ -73,5 +74,51 @@ export class BridgeError extends Error {
     if (originalError && typeof originalError === 'object') {
       Object.assign(this, getPropsToCopy(originalError));
     }
+  }
+}
+
+export class ApiCallError extends Error {
+  constructor(message, originalError) {
+    super(message);
+    this.name = this.constructor.name;
+    this.originalError = originalError;
+    if (originalError && typeof originalError === 'object') {
+      Object.assign(this, getPropsToCopy(originalError));
+    }
+  }
+}
+
+export class SmsCallError extends ApiCallError {
+  constructor(message, ...args) {
+    super(`SMS error: ${message}`, ...args);
+    this.name = this.constructor.name;
+  }
+}
+
+export class ResultProxyCallError extends ApiCallError {
+  constructor(message, ...args) {
+    super(`Result Proxy error: ${message}`, ...args);
+    this.name = this.constructor.name;
+  }
+}
+
+export class MarketCallError extends ApiCallError {
+  constructor(message, ...args) {
+    super(`Market API error: ${message}`, ...args);
+    this.name = this.constructor.name;
+  }
+}
+
+export class IpfsGatewayCallError extends ApiCallError {
+  constructor(message, ...args) {
+    super(`IPFS gateway error: ${message}`, ...args);
+    this.name = this.constructor.name;
+  }
+}
+
+export class WorkerpoolCallError extends ApiCallError {
+  constructor(message, ...args) {
+    super(`Workerpool API error: ${message}`, ...args);
+    this.name = this.constructor.name;
   }
 }

--- a/src/common/utils/errors.js
+++ b/src/common/utils/errors.js
@@ -83,9 +83,6 @@ export class ApiCallError extends Error {
     super(message, { cause: originalError });
     this.name = this.constructor.name;
     this.originalError = originalError; // deprecated
-    if (originalError && typeof originalError === 'object') {
-      Object.assign(this, getPropsToCopy(originalError));
-    }
   }
 }
 

--- a/src/common/utils/errors.js
+++ b/src/common/utils/errors.js
@@ -23,9 +23,9 @@ export class ConfigurationError extends Error {
 
 export class Web3ProviderError extends Error {
   constructor(message, originalError) {
-    super(message);
+    super(message, { cause: originalError });
     this.name = this.constructor.name;
-    this.originalError = originalError;
+    this.originalError = originalError; // deprecated
     if (originalError && typeof originalError === 'object') {
       Object.assign(this, getPropsToCopy(originalError));
     }
@@ -67,10 +67,11 @@ export class BridgeError extends Error {
   constructor(originalError, sendTxHash) {
     super(
       `Failed to get bridged chain confirmation for transaction ${sendTxHash}`,
+      { cause: originalError },
     );
     this.name = this.constructor.name;
     this.sendTxHash = sendTxHash;
-    this.originalError = originalError;
+    this.originalError = originalError; // deprecated
     if (originalError && typeof originalError === 'object') {
       Object.assign(this, getPropsToCopy(originalError));
     }
@@ -79,9 +80,9 @@ export class BridgeError extends Error {
 
 export class ApiCallError extends Error {
   constructor(message, originalError) {
-    super(message);
+    super(message, { cause: originalError });
     this.name = this.constructor.name;
-    this.originalError = originalError;
+    this.originalError = originalError; // deprecated
     if (originalError && typeof originalError === 'object') {
       Object.assign(this, getPropsToCopy(originalError));
     }

--- a/src/lib/errors.d.ts
+++ b/src/lib/errors.d.ts
@@ -52,7 +52,7 @@ export class BridgeError extends Error {
 }
 
 /**
- * ApiCallError encapsulates an error occurring during a call to an API such as a network error or a server internal error.
+ * ApiCallError encapsulates an error occurring during a call to an API such as a network error or a server-side internal error.
  */
 export class ApiCallError extends Error {
   constructor(message: string, originalError: Error);
@@ -64,26 +64,26 @@ export class ApiCallError extends Error {
 }
 
 /**
- * SmsCallError encapsulates an error occurring during a call to the SMS API such as a network error or a server internal error.
+ * SmsCallError encapsulates an error occurring during a call to the SMS API such as a network error or a server-side internal error.
  */
 export class SmsCallError extends ApiCallError {}
 
 /**
- * ResultProxyCallError encapsulates an error occurring during a call to the Result Proxy API such as a network error or a server internal error.
+ * ResultProxyCallError encapsulates an error occurring during a call to the Result Proxy API such as a network error or a server-side internal error.
  */
 export class ResultProxyCallError extends ApiCallError {}
 
 /**
- * MarketCallError encapsulates an error occurring during a call to the Market API such as a network error or a server internal error.
+ * MarketCallError encapsulates an error occurring during a call to the Market API such as a network error or a server-side internal error.
  */
 export class MarketCallError extends ApiCallError {}
 
 /**
- * IpfsGatewayCallError encapsulates an error occurring during a call to the IPFS gateway API such as a network error or a server internal error.
+ * IpfsGatewayCallError encapsulates an error occurring during a call to the IPFS gateway API such as a network error or a server-side internal error.
  */
 export class IpfsGatewayCallError extends ApiCallError {}
 
 /**
- * WorkerpoolCallError encapsulates an error occurring during a call to a workerpool API such as a network error or a server internal error.
+ * WorkerpoolCallError encapsulates an error occurring during a call to a workerpool API such as a network error or a server-side internal error.
  */
 export class WorkerpoolCallError extends ApiCallError {}

--- a/src/lib/errors.d.ts
+++ b/src/lib/errors.d.ts
@@ -69,7 +69,7 @@ export class ApiCallError extends Error {
 export class SmsCallError extends ApiCallError {}
 
 /**
- * ResultProxyCallError encapsulate an error occurring during a call to the Result-Proxy API such as a network error or a server internal error.
+ * ResultProxyCallError encapsulate an error occurring during a call to the Result Proxy API such as a network error or a server internal error.
  */
 export class ResultProxyCallError extends ApiCallError {}
 

--- a/src/lib/errors.d.ts
+++ b/src/lib/errors.d.ts
@@ -11,12 +11,24 @@ export class ConfigurationError extends Error {}
  * Web3ProviderError encapsulates an error thrown by the web3 provider.
  */
 export class Web3ProviderError extends Error {
-  constructor(message: string, originalError: Error);
+  constructor(
+    /**
+     * A descriptive error message detailing the nature of the error.
+     */
+    message: string,
+    /**
+     * The original Error object that caused this web3 provider error.
+     */
+    originalError: Error,
+  );
   /**
-   * @deprecated use Error cause instead
+   * @deprecated use Error cause instead.
    */
-  originalError?: Error;
-  cause?: Error;
+  originalError: Error;
+  /**
+   * The original Error object that caused this web3 provider error.
+   */
+  cause: Error;
 }
 /**
  * Web3ProviderCallError encapsulates an error thrown by the web3 provider during a web3 call.
@@ -31,36 +43,86 @@ export class Web3ProviderSendError extends Web3ProviderError {}
  */
 export class Web3ProviderSignMessageError extends Web3ProviderError {}
 /**
- * ObjectNotFoundError is thrown when trying to access an unknown resource.
+ * ObjectNotFoundError is thrown when trying to access an unknown onchain resource.
  */
 export class ObjectNotFoundError extends Error {
-  constructor(objName: string, objId: string, chainId: string);
-  objName?: string;
-  objId?: string;
-  chainId?: string;
+  constructor(
+    /**
+     * Name of the resource.
+     */
+    objName: string,
+    /**
+     * Id or address of the resource.
+     */
+    objId: string,
+    /**
+     * Chain id of the blockchain.
+     */
+    chainId: string,
+  );
+  /**
+   * Name of the resource.
+   */
+  objName: string;
+  /**
+   * Id or address of the resource.
+   */
+  objId: string;
+  /**
+   * Chain id of the blockchain.
+   */
+  chainId: string;
 }
 /**
  * BridgeError is thrown when bridging RLC between mainchain and sidechain fail before the value transfer confirmation.
  */
 export class BridgeError extends Error {
-  sendTxHash?: string;
+  constructor(
+    /**
+     * The original Error object that caused this API call error.
+     */
+    originalError: Error,
+    /**
+     * Hash of the transaction sending the value to the bridge contract.
+     */
+    sendTxHash: string,
+  );
+  /**
+   * Hash of the transaction sending the value to the bridge contract.
+   */
+  sendTxHash: string;
   /**
    * @deprecated use Error cause instead
    */
-  originalError?: Error;
-  cause?: Error;
+  originalError: Error;
+  /**
+   * The original Error object that caused this API call error.
+   */
+  cause: Error;
 }
 
 /**
  * ApiCallError encapsulates an error occurring during a call to an API such as a network error or a server-side internal error.
  */
 export class ApiCallError extends Error {
-  constructor(message: string, originalError: Error);
+  constructor(
+    /**
+     * A descriptive error message detailing the nature of the error.
+     */
+    message: string,
+    /**
+     * The original Error object that caused this API call error.
+     */
+    originalError: Error,
+  );
   /**
-   * @deprecated use Error cause instead
+   * @deprecated use Error cause instead.
    */
-  originalError?: Error;
-  cause?: Error;
+  originalError: Error;
+  /**
+   * The original Error object that caused this API call error.
+   */
+  cause: Error;
 }
 
 /**

--- a/src/lib/errors.d.ts
+++ b/src/lib/errors.d.ts
@@ -12,7 +12,11 @@ export class ConfigurationError extends Error {}
  */
 export class Web3ProviderError extends Error {
   constructor(message: string, originalError: Error);
+  /**
+   * @deprecated use Error cause instead
+   */
   originalError?: Error;
+  cause?: Error;
 }
 /**
  * Web3ProviderCallError encapsulate an error thrown by the web3 provider during a web3 call.
@@ -40,7 +44,11 @@ export class ObjectNotFoundError extends Error {
  */
 export class BridgeError extends Error {
   sendTxHash?: string;
+  /**
+   * @deprecated use Error cause instead
+   */
   originalError?: Error;
+  cause?: Error;
 }
 
 /**
@@ -48,7 +56,11 @@ export class BridgeError extends Error {
  */
 export class ApiCallError extends Error {
   constructor(message: string, originalError: Error);
+  /**
+   * @deprecated use Error cause instead
+   */
   originalError?: Error;
+  cause?: Error;
 }
 
 /**

--- a/src/lib/errors.d.ts
+++ b/src/lib/errors.d.ts
@@ -42,3 +42,36 @@ export class BridgeError extends Error {
   sendTxHash?: string;
   originalError?: Error;
 }
+
+/**
+ * ApiCallError encapsulate an error occurring during a call to an API such as a network error or a server internal error.
+ */
+export class ApiCallError extends Error {
+  constructor(message: string, originalError: Error);
+  originalError?: Error;
+}
+
+/**
+ * SmsCallError encapsulate an error occurring during a call to the SMS API such as a network error or a server internal error.
+ */
+export class SmsCallError extends ApiCallError {}
+
+/**
+ * ResultProxyCallError encapsulate an error occurring during a call to the Result-Proxy API such as a network error or a server internal error.
+ */
+export class ResultProxyCallError extends ApiCallError {}
+
+/**
+ * MarketCallError encapsulate an error occurring during a call to the Market API such as a network error or a server internal error.
+ */
+export class MarketCallError extends ApiCallError {}
+
+/**
+ * IpfsGatewayCallError encapsulate an error occurring during a call to the IPFS gateway API such as a network error or a server internal error.
+ */
+export class IpfsGatewayCallError extends ApiCallError {}
+
+/**
+ * WorkerpoolCallError encapsulate an error occurring during a call to a workerpool API such as a network error or a server internal error.
+ */
+export class WorkerpoolCallError extends ApiCallError {}

--- a/src/lib/errors.d.ts
+++ b/src/lib/errors.d.ts
@@ -8,7 +8,7 @@ export class ValidationError extends YupValidationError {}
  */
 export class ConfigurationError extends Error {}
 /**
- * Web3ProviderError encapsulate an error thrown by the web3 provider.
+ * Web3ProviderError encapsulates an error thrown by the web3 provider.
  */
 export class Web3ProviderError extends Error {
   constructor(message: string, originalError: Error);
@@ -19,15 +19,15 @@ export class Web3ProviderError extends Error {
   cause?: Error;
 }
 /**
- * Web3ProviderCallError encapsulate an error thrown by the web3 provider during a web3 call.
+ * Web3ProviderCallError encapsulates an error thrown by the web3 provider during a web3 call.
  */
 export class Web3ProviderCallError extends Web3ProviderError {}
 /**
- * Web3ProviderSendError encapsulate an error thrown by the web3 provider during a transaction.
+ * Web3ProviderSendError encapsulates an error thrown by the web3 provider during a transaction.
  */
 export class Web3ProviderSendError extends Web3ProviderError {}
 /**
- * Web3ProviderSignMessageError encapsulate an error thrown by the web3 provider during a message signature.
+ * Web3ProviderSignMessageError encapsulates an error thrown by the web3 provider during a message signature.
  */
 export class Web3ProviderSignMessageError extends Web3ProviderError {}
 /**
@@ -52,7 +52,7 @@ export class BridgeError extends Error {
 }
 
 /**
- * ApiCallError encapsulate an error occurring during a call to an API such as a network error or a server internal error.
+ * ApiCallError encapsulates an error occurring during a call to an API such as a network error or a server internal error.
  */
 export class ApiCallError extends Error {
   constructor(message: string, originalError: Error);
@@ -64,26 +64,26 @@ export class ApiCallError extends Error {
 }
 
 /**
- * SmsCallError encapsulate an error occurring during a call to the SMS API such as a network error or a server internal error.
+ * SmsCallError encapsulates an error occurring during a call to the SMS API such as a network error or a server internal error.
  */
 export class SmsCallError extends ApiCallError {}
 
 /**
- * ResultProxyCallError encapsulate an error occurring during a call to the Result Proxy API such as a network error or a server internal error.
+ * ResultProxyCallError encapsulates an error occurring during a call to the Result Proxy API such as a network error or a server internal error.
  */
 export class ResultProxyCallError extends ApiCallError {}
 
 /**
- * MarketCallError encapsulate an error occurring during a call to the Market API such as a network error or a server internal error.
+ * MarketCallError encapsulates an error occurring during a call to the Market API such as a network error or a server internal error.
  */
 export class MarketCallError extends ApiCallError {}
 
 /**
- * IpfsGatewayCallError encapsulate an error occurring during a call to the IPFS gateway API such as a network error or a server internal error.
+ * IpfsGatewayCallError encapsulates an error occurring during a call to the IPFS gateway API such as a network error or a server internal error.
  */
 export class IpfsGatewayCallError extends ApiCallError {}
 
 /**
- * WorkerpoolCallError encapsulate an error occurring during a call to a workerpool API such as a network error or a server internal error.
+ * WorkerpoolCallError encapsulates an error occurring during a call to a workerpool API such as a network error or a server internal error.
  */
 export class WorkerpoolCallError extends ApiCallError {}

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       retries: 3
       start_period: 30s
 
-  server-error-500:
+  service-internal-error:
     image: nginx:alpine
     volumes:
       - $PWD/mock/server/http500.nginx.conf:/etc/nginx/conf.d/default.conf

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -31,6 +31,15 @@ services:
       retries: 3
       start_period: 30s
 
+  server-error-500:
+    image: nginx:alpine
+    volumes:
+      - $PWD/mock/server/http500.nginx.conf:/etc/nginx/conf.d/default.conf
+    expose:
+      - 80
+    ports:
+      - 5500:80
+
   sms:
     image: iexechub/iexec-sms:7.1.0
     restart: unless-stopped

--- a/test/lib/e2e/IExecDatasetModule.test.js
+++ b/test/lib/e2e/IExecDatasetModule.test.js
@@ -4,16 +4,23 @@ import { describe, test, expect } from '@jest/globals';
 import { join } from 'path';
 import { BN } from 'bn.js';
 import fsExtra from 'fs-extra';
-import { deployRandomDataset, getTestConfig } from '../lib-test-utils';
+import {
+  deployRandomDataset,
+  expectAsyncCustomError,
+  getTestConfig,
+} from '../lib-test-utils';
 import {
   TEST_CHAINS,
   TEE_FRAMEWORKS,
   execAsync,
   getId,
   getRandomAddress,
+  SERVICE_HTTP_500_URL,
+  SERVICE_UNREACHABLE_URL,
 } from '../../test-utils';
 import '../../jest-setup';
 import { errors } from '../../../src/lib';
+import { SmsCallError } from '../../../src/lib/errors';
 
 const { readFile, ensureDir, writeFile } = fsExtra;
 
@@ -319,6 +326,45 @@ describe('dataset', () => {
   });
 
   describe('checkDatasetSecretExists()', () => {
+    let randomDatasetAddress;
+    beforeAll(async () => {
+      const { iexec } = getTestConfig(iexecTestChain)();
+      const { address } = await deployRandomDataset(iexec);
+      randomDatasetAddress = address;
+    });
+
+    test("throw a SmsCallError when the SMS can't be reached", async () => {
+      const { iexec: readOnlyIExec } = getTestConfig(iexecTestChain)({
+        readOnly: true,
+        options: {
+          smsURL: SERVICE_UNREACHABLE_URL,
+        },
+      });
+      await expectAsyncCustomError(
+        readOnlyIExec.dataset.checkDatasetSecretExists(randomDatasetAddress),
+        {
+          constructor: SmsCallError,
+          message: `SMS error: Connection to ${SERVICE_UNREACHABLE_URL} failed with a network error`,
+        },
+      );
+    });
+
+    test('throw a SmsCallError when the SMS encounters an error', async () => {
+      const { iexec: readOnlyIExec } = getTestConfig(iexecTestChain)({
+        readOnly: true,
+        options: {
+          smsURL: SERVICE_HTTP_500_URL,
+        },
+      });
+      await expectAsyncCustomError(
+        readOnlyIExec.dataset.checkDatasetSecretExists(randomDatasetAddress),
+        {
+          constructor: SmsCallError,
+          message: `SMS error: Server at ${SERVICE_HTTP_500_URL} encountered an internal error`,
+        },
+      );
+    });
+
     test('checks a dataset secret exist on default TEE framework SMS', async () => {
       const { iexec: readOnlyIExec } = getTestConfig(iexecTestChain)({
         readOnly: true,
@@ -368,6 +414,47 @@ describe('dataset', () => {
   });
 
   describe('pushDatasetSecret()', () => {
+    let randomDatasetAddress;
+    let randomDatasetOwnerWallet;
+    beforeAll(async () => {
+      const { iexec, wallet } = getTestConfig(iexecTestChain)();
+      const { address } = await deployRandomDataset(iexec);
+      randomDatasetAddress = address;
+      randomDatasetOwnerWallet = wallet;
+    });
+
+    test("throw a SmsCallError when the SMS can't be reached", async () => {
+      const { iexec } = getTestConfig(iexecTestChain)({
+        privateKey: randomDatasetOwnerWallet.privateKey,
+        options: {
+          smsURL: SERVICE_UNREACHABLE_URL,
+        },
+      });
+      await expectAsyncCustomError(
+        iexec.dataset.pushDatasetSecret(randomDatasetAddress, 'foo'),
+        {
+          constructor: SmsCallError,
+          message: `SMS error: Connection to ${SERVICE_UNREACHABLE_URL} failed with a network error`,
+        },
+      );
+    });
+
+    test('throw a SmsCallError when the SMS encounters an error', async () => {
+      const { iexec } = getTestConfig(iexecTestChain)({
+        privateKey: randomDatasetOwnerWallet.privateKey,
+        options: {
+          smsURL: SERVICE_HTTP_500_URL,
+        },
+      });
+      await expectAsyncCustomError(
+        iexec.dataset.pushDatasetSecret(randomDatasetAddress, 'foo'),
+        {
+          constructor: SmsCallError,
+          message: `SMS error: Server at ${SERVICE_HTTP_500_URL} encountered an internal error`,
+        },
+      );
+    });
+
     test('only owner can push secret', async () => {
       const { iexec: iexecDatasetOwner } = getTestConfig(iexecTestChain)();
       const { iexec: iexecRandom, wallet: randomWallet } =

--- a/test/lib/e2e/IExecDealModule.test.js
+++ b/test/lib/e2e/IExecDealModule.test.js
@@ -5,6 +5,7 @@ import {
   deployAndGetApporder,
   deployAndGetDatasetorder,
   deployAndGetWorkerpoolorder,
+  expectAsyncCustomError,
   getMatchableRequestorder,
   getTestConfig,
   runObservableSubscribe,
@@ -15,16 +16,53 @@ import {
   initializeTask,
   sleep,
   adminCreateCategory,
+  SERVICE_UNREACHABLE_URL,
+  getRandomBytes32,
+  SERVICE_HTTP_500_URL,
+  getRandomAddress,
 } from '../../test-utils';
 import '../../jest-setup';
 
 import { errors } from '../../../src/lib/index';
+import { MarketCallError } from '../../../src/lib/errors';
 
 const { ObjectNotFoundError } = errors;
 
 const iexecTestChain = TEST_CHAINS['bellecour-fork'];
 describe('deal', () => {
   describe('fetchRequesterDeals()', () => {
+    test("throw a MarketCallError when the Market API can't be reached", async () => {
+      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+        readOnly: true,
+        options: {
+          iexecGatewayURL: SERVICE_UNREACHABLE_URL,
+        },
+      });
+      await expectAsyncCustomError(
+        iexecReadOnly.deal.fetchRequesterDeals(getRandomAddress()),
+        {
+          constructor: MarketCallError,
+          message: `Market API error: Connection to ${SERVICE_UNREACHABLE_URL} failed with a network error`,
+        },
+      );
+    });
+
+    test('throw a SmsCallError when the SMS encounters an error', async () => {
+      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+        readOnly: true,
+        options: {
+          iexecGatewayURL: SERVICE_HTTP_500_URL,
+        },
+      });
+      await expectAsyncCustomError(
+        iexecReadOnly.deal.fetchRequesterDeals(getRandomAddress()),
+        {
+          constructor: MarketCallError,
+          message: `Market API error: Server at ${SERVICE_HTTP_500_URL} encountered an internal error`,
+        },
+      );
+    });
+
     test('shows past deals', async () => {
       const { iexec } = getTestConfig(iexecTestChain)();
       const requesterAddress = await iexec.wallet.getAddress();
@@ -87,132 +125,169 @@ describe('deal', () => {
     });
   });
 
-  describe('fetchDealsByApporder()', () => {
-    test('shows past deals', async () => {
-      const { iexec } = getTestConfig(iexecTestChain)();
-      const apporder = await deployAndGetApporder(iexec);
-      const datasetorder = await deployAndGetDatasetorder(iexec);
-      const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
-      const requestorder = await getMatchableRequestorder(iexec, {
-        apporder,
-        datasetorder,
-        workerpoolorder,
-      });
-      const orderHash = await iexec.order.hashApporder(apporder);
-      const res = await iexec.deal.fetchDealsByApporder(orderHash);
-      expect(res.count).toBe(0);
-      const { dealid } = await iexec.order.matchOrders(
-        {
-          apporder,
-          datasetorder,
-          workerpoolorder,
-          requestorder,
+  describe('fetchDealsBy...order()', () => {
+    test("throw a MarketCallError when the Market API can't be reached", async () => {
+      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+        readOnly: true,
+        options: {
+          iexecGatewayURL: SERVICE_UNREACHABLE_URL,
         },
-        { preflightCheck: false },
-      );
-      await sleep(5000);
-      const resAfterMatch = await iexec.deal.fetchDealsByApporder(orderHash);
-      expect(resAfterMatch.count).toBe(1);
-      expect(resAfterMatch.deals[0].dealid).toBe(dealid);
-      expect(resAfterMatch.deals[0].app.pointer).toBe(apporder.app);
-    });
-  });
-
-  describe('fetchDealsByDatasetorder()', () => {
-    test('shows past deals', async () => {
-      const { iexec } = getTestConfig(iexecTestChain)();
-      const apporder = await deployAndGetApporder(iexec);
-      const datasetorder = await deployAndGetDatasetorder(iexec);
-      const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
-      const requestorder = await getMatchableRequestorder(iexec, {
-        apporder,
-        datasetorder,
-        workerpoolorder,
       });
-      const orderHash = await iexec.order.hashDatasetorder(datasetorder);
-      const res = await iexec.deal.fetchDealsByDatasetorder(orderHash);
-      expect(res.count).toBe(0);
-      const { dealid } = await iexec.order.matchOrders(
+      await expectAsyncCustomError(
+        iexecReadOnly.deal.fetchDealsByApporder(getRandomBytes32()),
         {
-          apporder,
-          datasetorder,
-          workerpoolorder,
-          requestorder,
+          constructor: MarketCallError,
+          message: `Market API error: Connection to ${SERVICE_UNREACHABLE_URL} failed with a network error`,
         },
-        { preflightCheck: false },
-      );
-      await sleep(5000);
-      const resAfterMatch =
-        await iexec.deal.fetchDealsByDatasetorder(orderHash);
-      expect(resAfterMatch.count).toBe(1);
-      expect(resAfterMatch.deals[0].dealid).toBe(dealid);
-      expect(resAfterMatch.deals[0].dataset.pointer).toBe(datasetorder.dataset);
-    });
-  });
-
-  describe('fetchDealsByWorkerpoolorder()', () => {
-    test('shows past deals', async () => {
-      const { iexec } = getTestConfig(iexecTestChain)();
-      const apporder = await deployAndGetApporder(iexec);
-      const datasetorder = await deployAndGetDatasetorder(iexec);
-      const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
-      const requestorder = await getMatchableRequestorder(iexec, {
-        apporder,
-        datasetorder,
-        workerpoolorder,
-      });
-      const orderHash = await iexec.order.hashWorkerpoolorder(workerpoolorder);
-      const res = await iexec.deal.fetchDealsByWorkerpoolorder(orderHash);
-      expect(res.count).toBe(0);
-      const { dealid } = await iexec.order.matchOrders(
-        {
-          apporder,
-          datasetorder,
-          workerpoolorder,
-          requestorder,
-        },
-        { preflightCheck: false },
-      );
-      await sleep(5000);
-      const resAfterMatch =
-        await iexec.deal.fetchDealsByWorkerpoolorder(orderHash);
-      expect(resAfterMatch.count).toBe(1);
-      expect(resAfterMatch.deals[0].dealid).toBe(dealid);
-      expect(resAfterMatch.deals[0].workerpool.pointer).toBe(
-        workerpoolorder.workerpool,
       );
     });
-  });
 
-  describe('fetchDealsByRequestorder()', () => {
-    test('shows past deals', async () => {
-      const { iexec } = getTestConfig(iexecTestChain)();
-      const apporder = await deployAndGetApporder(iexec);
-      const datasetorder = await deployAndGetDatasetorder(iexec);
-      const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
-      const requestorder = await getMatchableRequestorder(iexec, {
-        apporder,
-        datasetorder,
-        workerpoolorder,
+    test('throw a SmsCallError when the SMS encounters an error', async () => {
+      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+        readOnly: true,
+        options: {
+          iexecGatewayURL: SERVICE_HTTP_500_URL,
+        },
       });
-      const orderHash = await iexec.order.hashRequestorder(requestorder);
-      const res = await iexec.deal.fetchDealsByRequestorder(orderHash);
-      expect(res.count).toBe(0);
-      const { dealid } = await iexec.order.matchOrders(
+      await expectAsyncCustomError(
+        iexecReadOnly.deal.fetchDealsByApporder(getRandomBytes32()),
         {
+          constructor: MarketCallError,
+          message: `Market API error: Server at ${SERVICE_HTTP_500_URL} encountered an internal error`,
+        },
+      );
+    });
+
+    describe('fetchDealsByApporder()', () => {
+      test('shows past deals', async () => {
+        const { iexec } = getTestConfig(iexecTestChain)();
+        const apporder = await deployAndGetApporder(iexec);
+        const datasetorder = await deployAndGetDatasetorder(iexec);
+        const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
+        const requestorder = await getMatchableRequestorder(iexec, {
           apporder,
           datasetorder,
           workerpoolorder,
-          requestorder,
-        },
-        { preflightCheck: false },
-      );
-      await sleep(5000);
-      const resAfterMatch =
-        await iexec.deal.fetchDealsByRequestorder(orderHash);
-      expect(resAfterMatch.count).toBe(1);
-      expect(resAfterMatch.deals[0].dealid).toBe(dealid);
-      expect(resAfterMatch.deals[0].requester).toBe(requestorder.requester);
+        });
+        const orderHash = await iexec.order.hashApporder(apporder);
+        const res = await iexec.deal.fetchDealsByApporder(orderHash);
+        expect(res.count).toBe(0);
+        const { dealid } = await iexec.order.matchOrders(
+          {
+            apporder,
+            datasetorder,
+            workerpoolorder,
+            requestorder,
+          },
+          { preflightCheck: false },
+        );
+        await sleep(5000);
+        const resAfterMatch = await iexec.deal.fetchDealsByApporder(orderHash);
+        expect(resAfterMatch.count).toBe(1);
+        expect(resAfterMatch.deals[0].dealid).toBe(dealid);
+        expect(resAfterMatch.deals[0].app.pointer).toBe(apporder.app);
+      });
+    });
+
+    describe('fetchDealsByDatasetorder()', () => {
+      test('shows past deals', async () => {
+        const { iexec } = getTestConfig(iexecTestChain)();
+        const apporder = await deployAndGetApporder(iexec);
+        const datasetorder = await deployAndGetDatasetorder(iexec);
+        const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
+        const requestorder = await getMatchableRequestorder(iexec, {
+          apporder,
+          datasetorder,
+          workerpoolorder,
+        });
+        const orderHash = await iexec.order.hashDatasetorder(datasetorder);
+        const res = await iexec.deal.fetchDealsByDatasetorder(orderHash);
+        expect(res.count).toBe(0);
+        const { dealid } = await iexec.order.matchOrders(
+          {
+            apporder,
+            datasetorder,
+            workerpoolorder,
+            requestorder,
+          },
+          { preflightCheck: false },
+        );
+        await sleep(5000);
+        const resAfterMatch =
+          await iexec.deal.fetchDealsByDatasetorder(orderHash);
+        expect(resAfterMatch.count).toBe(1);
+        expect(resAfterMatch.deals[0].dealid).toBe(dealid);
+        expect(resAfterMatch.deals[0].dataset.pointer).toBe(
+          datasetorder.dataset,
+        );
+      });
+    });
+
+    describe('fetchDealsByWorkerpoolorder()', () => {
+      test('shows past deals', async () => {
+        const { iexec } = getTestConfig(iexecTestChain)();
+        const apporder = await deployAndGetApporder(iexec);
+        const datasetorder = await deployAndGetDatasetorder(iexec);
+        const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
+        const requestorder = await getMatchableRequestorder(iexec, {
+          apporder,
+          datasetorder,
+          workerpoolorder,
+        });
+        const orderHash =
+          await iexec.order.hashWorkerpoolorder(workerpoolorder);
+        const res = await iexec.deal.fetchDealsByWorkerpoolorder(orderHash);
+        expect(res.count).toBe(0);
+        const { dealid } = await iexec.order.matchOrders(
+          {
+            apporder,
+            datasetorder,
+            workerpoolorder,
+            requestorder,
+          },
+          { preflightCheck: false },
+        );
+        await sleep(5000);
+        const resAfterMatch =
+          await iexec.deal.fetchDealsByWorkerpoolorder(orderHash);
+        expect(resAfterMatch.count).toBe(1);
+        expect(resAfterMatch.deals[0].dealid).toBe(dealid);
+        expect(resAfterMatch.deals[0].workerpool.pointer).toBe(
+          workerpoolorder.workerpool,
+        );
+      });
+    });
+
+    describe('fetchDealsByRequestorder()', () => {
+      test('shows past deals', async () => {
+        const { iexec } = getTestConfig(iexecTestChain)();
+        const apporder = await deployAndGetApporder(iexec);
+        const datasetorder = await deployAndGetDatasetorder(iexec);
+        const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
+        const requestorder = await getMatchableRequestorder(iexec, {
+          apporder,
+          datasetorder,
+          workerpoolorder,
+        });
+        const orderHash = await iexec.order.hashRequestorder(requestorder);
+        const res = await iexec.deal.fetchDealsByRequestorder(orderHash);
+        expect(res.count).toBe(0);
+        const { dealid } = await iexec.order.matchOrders(
+          {
+            apporder,
+            datasetorder,
+            workerpoolorder,
+            requestorder,
+          },
+          { preflightCheck: false },
+        );
+        await sleep(5000);
+        const resAfterMatch =
+          await iexec.deal.fetchDealsByRequestorder(orderHash);
+        expect(resAfterMatch.count).toBe(1);
+        expect(resAfterMatch.deals[0].dealid).toBe(dealid);
+        expect(resAfterMatch.deals[0].requester).toBe(requestorder.requester);
+      });
     });
   });
 

--- a/test/lib/e2e/IExecDealModule.test.js
+++ b/test/lib/e2e/IExecDealModule.test.js
@@ -47,7 +47,7 @@ describe('deal', () => {
       );
     });
 
-    test('throw a SmsCallError when the SMS encounters an error', async () => {
+    test('throw a MarketCallError when the Market API encounters an error', async () => {
       const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
         readOnly: true,
         options: {
@@ -142,7 +142,7 @@ describe('deal', () => {
       );
     });
 
-    test('throw a SmsCallError when the SMS encounters an error', async () => {
+    test('throw a MarketCallError when the Market API encounters an error', async () => {
       const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
         readOnly: true,
         options: {

--- a/test/lib/e2e/IExecOrderModule.test.js
+++ b/test/lib/e2e/IExecOrderModule.test.js
@@ -825,7 +825,7 @@ describe('order', () => {
   });
 
   describe('publish...order()', () => {
-    test("throw a MarketCallError when the SMS can't be reached", async () => {
+    test("throw a MarketCallError when the Market API can't be reached", async () => {
       const { iexec } = getTestConfig(iexecTestChain)({
         options: {
           iexecGatewayURL: SERVICE_UNREACHABLE_URL,
@@ -843,7 +843,7 @@ describe('order', () => {
       );
     });
 
-    test('throw a MarketCallError when the SMS encounters an error', async () => {
+    test('throw a MarketCallError when the Market API encounters an error', async () => {
       const { iexec } = getTestConfig(iexecTestChain)({
         options: {
           iexecGatewayURL: SERVICE_HTTP_500_URL,
@@ -1027,7 +1027,7 @@ describe('order', () => {
   });
 
   describe('unpublish...order()', () => {
-    test("throw a MarketCallError when the SMS can't be reached", async () => {
+    test("throw a MarketCallError when the Market API can't be reached", async () => {
       const { iexec } = getTestConfig(iexecTestChain)({
         options: {
           iexecGatewayURL: SERVICE_UNREACHABLE_URL,
@@ -1039,7 +1039,7 @@ describe('order', () => {
       });
     });
 
-    test('throw a MarketCallError when the SMS encounters an error', async () => {
+    test('throw a MarketCallError when the Market API encounters an error', async () => {
       const { iexec } = getTestConfig(iexecTestChain)({
         options: {
           iexecGatewayURL: SERVICE_HTTP_500_URL,

--- a/test/lib/e2e/IExecOrderbookModule.test.js
+++ b/test/lib/e2e/IExecOrderbookModule.test.js
@@ -40,7 +40,7 @@ describe('orderbook', () => {
       );
     });
 
-    test('throw a SmsCallError when the SMS encounters an error', async () => {
+    test('throw a MarketCallError when the Market API encounters an error', async () => {
       const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
         readOnly: true,
         options: {
@@ -179,7 +179,7 @@ describe('orderbook', () => {
       );
     });
 
-    test('throw a SmsCallError when the SMS encounters an error', async () => {
+    test('throw a MarketCallError when the Market API encounters an error', async () => {
       const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
         readOnly: true,
         options: {

--- a/test/lib/e2e/IExecOrderbookModule.test.js
+++ b/test/lib/e2e/IExecOrderbookModule.test.js
@@ -5,1078 +5,1172 @@ import {
   deployAndGetApporder,
   deployAndGetDatasetorder,
   deployAndGetWorkerpoolorder,
+  expectAsyncCustomError,
   getMatchableRequestorder,
   getTestConfig,
 } from '../lib-test-utils';
-import { TEST_CHAINS, NULL_ADDRESS, getRandomAddress } from '../../test-utils';
+import {
+  TEST_CHAINS,
+  NULL_ADDRESS,
+  getRandomAddress,
+  SERVICE_UNREACHABLE_URL,
+  SERVICE_HTTP_500_URL,
+  getRandomBytes32,
+} from '../../test-utils';
 import '../../jest-setup';
+import { MarketCallError } from '../../../src/lib/errors';
 
 const iexecTestChain = TEST_CHAINS['bellecour-fork'];
 
 describe('orderbook', () => {
-  describe('fetchApporder()', () => {
-    test('anyone can get a published order by hash', async () => {
-      const { iexec } = getTestConfig(iexecTestChain)();
+  describe('fetch...Order()', () => {
+    test("throw a MarketCallError when the Market API can't be reached", async () => {
       const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
         readOnly: true,
+        options: {
+          iexecGatewayURL: SERVICE_UNREACHABLE_URL,
+        },
       });
-      const apporder = await deployAndGetApporder(iexec);
-      const orderHash = await iexecReadOnly.order.hashApporder(apporder);
-      await expect(
-        iexecReadOnly.orderbook.fetchApporder(orderHash),
-      ).rejects.toThrow(Error('API error: apporder not found'));
-      await iexec.order.publishApporder(apporder);
-      const found = await iexecReadOnly.orderbook.fetchApporder(orderHash);
-      expect(found.order).toLooseEqual(apporder);
-      expect(found.status).toBe('open');
-      expect(found.remaining).toBe(1);
-      expect(found.publicationTimestamp).toBeDefined();
+      await expectAsyncCustomError(
+        iexecReadOnly.orderbook.fetchApporder(getRandomBytes32()),
+        {
+          constructor: MarketCallError,
+          message: `Market API error: Connection to ${SERVICE_UNREACHABLE_URL} failed with a network error`,
+        },
+      );
+    });
+
+    test('throw a SmsCallError when the SMS encounters an error', async () => {
+      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+        readOnly: true,
+        options: {
+          iexecGatewayURL: SERVICE_HTTP_500_URL,
+        },
+      });
+      await expectAsyncCustomError(
+        iexecReadOnly.orderbook.fetchApporder(getRandomBytes32()),
+        {
+          constructor: MarketCallError,
+          message: `Market API error: Server at ${SERVICE_HTTP_500_URL} encountered an internal error`,
+        },
+      );
+    });
+
+    describe('fetchApporder()', () => {
+      test('anyone can get a published order by hash', async () => {
+        const { iexec } = getTestConfig(iexecTestChain)();
+        const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+          readOnly: true,
+        });
+        const apporder = await deployAndGetApporder(iexec);
+        const orderHash = await iexecReadOnly.order.hashApporder(apporder);
+        await expect(
+          iexecReadOnly.orderbook.fetchApporder(orderHash),
+        ).rejects.toThrow(Error('API error: apporder not found'));
+        await iexec.order.publishApporder(apporder);
+        const found = await iexecReadOnly.orderbook.fetchApporder(orderHash);
+        expect(found.order).toLooseEqual(apporder);
+        expect(found.status).toBe('open');
+        expect(found.remaining).toBe(1);
+        expect(found.publicationTimestamp).toBeDefined();
+      });
+    });
+
+    describe('fetchDatasetorder()', () => {
+      test('anyone can get a published order by hash', async () => {
+        const { iexec } = getTestConfig(iexecTestChain)();
+        const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+          readOnly: true,
+        });
+        const datasetorder = await deployAndGetDatasetorder(iexec);
+        const orderHash = await iexec.order.hashDatasetorder(datasetorder);
+        await expect(
+          iexecReadOnly.orderbook.fetchDatasetorder(orderHash),
+        ).rejects.toThrow(Error('API error: datasetorder not found'));
+        await iexec.order.publishDatasetorder(datasetorder, {
+          preflightCheck: false,
+        });
+        const found =
+          await iexecReadOnly.orderbook.fetchDatasetorder(orderHash);
+        expect(found.order).toLooseEqual(datasetorder);
+        expect(found.status).toBe('open');
+        expect(found.remaining).toBe(1);
+        expect(found.publicationTimestamp).toBeDefined();
+      });
+    });
+
+    describe('fetchWorkerpoolorder()', () => {
+      test('anyone can get a published order by hash', async () => {
+        const { iexec } = getTestConfig(iexecTestChain)();
+        const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+          readOnly: true,
+        });
+        const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
+        const orderHash =
+          await iexec.order.hashWorkerpoolorder(workerpoolorder);
+        await expect(
+          iexecReadOnly.orderbook.fetchWorkerpoolorder(orderHash),
+        ).rejects.toThrow(Error('API error: workerpoolorder not found'));
+        await iexec.order.publishWorkerpoolorder(workerpoolorder);
+        const found =
+          await iexecReadOnly.orderbook.fetchWorkerpoolorder(orderHash);
+        expect(found.order).toLooseEqual(workerpoolorder);
+        expect(found.status).toBe('open');
+        expect(found.remaining).toBe(1);
+        expect(found.publicationTimestamp).toBeDefined();
+      });
+    });
+
+    describe('fetchRequestorder()', () => {
+      test('anyone can get a published order by hash', async () => {
+        const { iexec, wallet } = getTestConfig(iexecTestChain)();
+        const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+          readOnly: true,
+        });
+        const apporder = await deployAndGetApporder(iexec);
+        await iexec.order.publishApporder(apporder);
+        const requestorder = await iexec.order
+          .createRequestorder({
+            requester: wallet.address,
+            app: apporder.app,
+            appmaxprice: apporder.appprice,
+            dataset: NULL_ADDRESS,
+            datasetmaxprice: 0,
+            workerpool: NULL_ADDRESS,
+            workerpoolmaxprice: 0,
+            category: 1,
+            trust: 0,
+            volume: 1,
+          })
+          .then((o) =>
+            iexec.order.signRequestorder(o, { preflightCheck: false }),
+          );
+        const orderHash = await iexec.order.hashRequestorder(requestorder);
+        await expect(
+          iexecReadOnly.orderbook.fetchRequestorder(orderHash),
+        ).rejects.toThrow(Error('API error: requestorder not found'));
+        await iexec.order.publishRequestorder(requestorder, {
+          preflightCheck: false,
+        });
+        const found =
+          await iexecReadOnly.orderbook.fetchRequestorder(orderHash);
+        expect(found.order).toLooseEqual(requestorder);
+        expect(found.status).toBe('open');
+        expect(found.remaining).toBe(1);
+        expect(found.publicationTimestamp).toBeDefined();
+      });
     });
   });
 
-  describe('fetchDatasetorder()', () => {
-    test('anyone can get a published order by hash', async () => {
-      const { iexec } = getTestConfig(iexecTestChain)();
+  describe('fetch...Orderbook()', () => {
+    test("throw a MarketCallError when the Market API can't be reached", async () => {
       const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
         readOnly: true,
+        options: {
+          iexecGatewayURL: SERVICE_UNREACHABLE_URL,
+        },
       });
-      const datasetorder = await deployAndGetDatasetorder(iexec);
-      const orderHash = await iexec.order.hashDatasetorder(datasetorder);
-      await expect(
-        iexecReadOnly.orderbook.fetchDatasetorder(orderHash),
-      ).rejects.toThrow(Error('API error: datasetorder not found'));
-      await iexec.order.publishDatasetorder(datasetorder, {
-        preflightCheck: false,
-      });
-      const found = await iexecReadOnly.orderbook.fetchDatasetorder(orderHash);
-      expect(found.order).toLooseEqual(datasetorder);
-      expect(found.status).toBe('open');
-      expect(found.remaining).toBe(1);
-      expect(found.publicationTimestamp).toBeDefined();
+      await expectAsyncCustomError(
+        iexecReadOnly.orderbook.fetchAppOrderbook(getRandomAddress()),
+        {
+          constructor: MarketCallError,
+          message: `Market API error: Connection to ${SERVICE_UNREACHABLE_URL} failed with a network error`,
+        },
+      );
     });
-  });
 
-  describe('fetchWorkerpoolorder()', () => {
-    test('anyone can get a published order by hash', async () => {
-      const { iexec } = getTestConfig(iexecTestChain)();
+    test('throw a SmsCallError when the SMS encounters an error', async () => {
       const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
         readOnly: true,
+        options: {
+          iexecGatewayURL: SERVICE_HTTP_500_URL,
+        },
       });
-      const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
-      const orderHash = await iexec.order.hashWorkerpoolorder(workerpoolorder);
-      await expect(
-        iexecReadOnly.orderbook.fetchWorkerpoolorder(orderHash),
-      ).rejects.toThrow(Error('API error: workerpoolorder not found'));
-      await iexec.order.publishWorkerpoolorder(workerpoolorder);
-      const found =
-        await iexecReadOnly.orderbook.fetchWorkerpoolorder(orderHash);
-      expect(found.order).toLooseEqual(workerpoolorder);
-      expect(found.status).toBe('open');
-      expect(found.remaining).toBe(1);
-      expect(found.publicationTimestamp).toBeDefined();
+      await expectAsyncCustomError(
+        iexecReadOnly.orderbook.fetchAppOrderbook(getRandomAddress()),
+        {
+          constructor: MarketCallError,
+          message: `Market API error: Server at ${SERVICE_HTTP_500_URL} encountered an internal error`,
+        },
+      );
     });
-  });
+    describe('fetchAppOrderbook()', () => {
+      test('returns orders available fo anyone', async () => {
+        const { iexec } = getTestConfig(iexecTestChain)();
+        const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+          readOnly: true,
+        });
+        const appAddress = getRandomAddress();
+        const res = await iexec.orderbook.fetchAppOrderbook(appAddress);
+        expect(res.count).toBe(0);
+        expect(res.orders).toStrictEqual([]);
+        const apporder = await deployAndGetApporder(iexec);
 
-  describe('fetchRequestorder()', () => {
-    test('anyone can get a published order by hash', async () => {
-      const { iexec, wallet } = getTestConfig(iexecTestChain)();
-      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
-        readOnly: true,
-      });
-      const apporder = await deployAndGetApporder(iexec);
-      await iexec.order.publishApporder(apporder);
-      const requestorder = await iexec.order
-        .createRequestorder({
-          requester: wallet.address,
-          app: apporder.app,
-          appmaxprice: apporder.appprice,
-          dataset: NULL_ADDRESS,
-          datasetmaxprice: 0,
-          workerpool: NULL_ADDRESS,
-          workerpoolmaxprice: 0,
-          category: 1,
-          trust: 0,
-          volume: 1,
-        })
-        .then((o) =>
-          iexec.order.signRequestorder(o, { preflightCheck: false }),
+        for (let i = 0; i < 22; i += 1) {
+          await iexec.order
+            .signApporder(apporder)
+            .then((o) => iexec.order.publishApporder(o));
+        }
+        for (let i = 0; i < 2; i += 1) {
+          await iexec.order
+            .signApporder({ ...apporder, datasetrestrict: getRandomAddress() })
+            .then((o) => iexec.order.publishApporder(o));
+        }
+        for (let i = 0; i < 3; i += 1) {
+          await iexec.order
+            .signApporder({
+              ...apporder,
+              workerpoolrestrict: getRandomAddress(),
+            })
+            .then((o) => iexec.order.publishApporder(o));
+        }
+        for (let i = 0; i < 4; i += 1) {
+          await iexec.order
+            .signApporder({
+              ...apporder,
+              requesterrestrict: getRandomAddress(),
+            })
+            .then((o) => iexec.order.publishApporder(o));
+        }
+        await deployAndGetApporder(iexec).then((o) =>
+          iexec.order.publishApporder(o),
         );
-      const orderHash = await iexec.order.hashRequestorder(requestorder);
-      await expect(
-        iexecReadOnly.orderbook.fetchRequestorder(orderHash),
-      ).rejects.toThrow(Error('API error: requestorder not found'));
-      await iexec.order.publishRequestorder(requestorder, {
-        preflightCheck: false,
+
+        const res1 = await iexecReadOnly.orderbook.fetchAppOrderbook(
+          apporder.app,
+        );
+        expect(res1.count).toBe(22);
+        expect(res1.orders.length).toBe(20);
+        expect(res1.more).toBeDefined();
+        const res2 = await res1.more();
+        expect(res2.count).toBe(22);
+        expect(res2.orders.length).toBe(2);
+        expect(res2.more).toBeUndefined();
+        const res3 = await iexecReadOnly.orderbook.fetchAppOrderbook(
+          apporder.app,
+          {
+            dataset: 'any',
+          },
+        );
+        expect(res3.count).toBe(24);
+        const res4 = await iexecReadOnly.orderbook.fetchAppOrderbook(
+          apporder.app,
+          {
+            workerpool: 'any',
+          },
+        );
+        expect(res4.count).toBe(25);
+        const res5 = await iexecReadOnly.orderbook.fetchAppOrderbook(
+          apporder.app,
+          {
+            requester: 'any',
+          },
+        );
+        expect(res5.count).toBe(26);
+        const res6 = await iexecReadOnly.orderbook.fetchAppOrderbook(
+          apporder.app,
+          {
+            dataset: 'any',
+            requester: 'any',
+            workerpool: 'any',
+          },
+        );
+        expect(res6.count).toBe(31);
+        const res7 = await iexecReadOnly.orderbook.fetchAppOrderbook('any', {
+          dataset: 'any',
+          requester: 'any',
+          workerpool: 'any',
+        });
+        expect(res7.count >= 32).toBe(true);
       });
-      const found = await iexecReadOnly.orderbook.fetchRequestorder(orderHash);
-      expect(found.order).toLooseEqual(requestorder);
-      expect(found.status).toBe('open');
-      expect(found.remaining).toBe(1);
-      expect(found.publicationTimestamp).toBeDefined();
+
+      test('strict option allow filtering only orders for specified dataset, workerpool or requester', async () => {
+        const { iexec } = getTestConfig(iexecTestChain)();
+        const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+          readOnly: true,
+        });
+
+        // 1 and 2: orders without any restrictions
+        const emptyAppOrder = await deployAndGetApporder(iexec);
+        const appAddress = emptyAppOrder.app;
+
+        await iexec.order
+          .signApporder(emptyAppOrder)
+          .then((o) => iexec.order.publishApporder(o));
+        await iexec.order
+          .signApporder(emptyAppOrder)
+          .then((o) => iexec.order.publishApporder(o));
+
+        // 3: dataset restricted order
+        const datasetAddress = getRandomAddress();
+        emptyAppOrder.datasetrestrict = datasetAddress;
+        await iexec.order
+          .signApporder(emptyAppOrder)
+          .then((o) => iexec.order.publishApporder(o));
+        // reset to empty
+        emptyAppOrder.datasetrestrict = NULL_ADDRESS;
+
+        // 4: workerpool restricted order
+        const workerpoolAddress = getRandomAddress();
+        emptyAppOrder.workerpoolrestrict = workerpoolAddress;
+        await iexec.order
+          .signApporder(emptyAppOrder)
+          .then((o) => iexec.order.publishApporder(o));
+        // reset to empty
+        emptyAppOrder.workerpoolrestrict = NULL_ADDRESS;
+
+        // 5: requester restricted order
+        const requesterAddress = getRandomAddress();
+        emptyAppOrder.requesterrestrict = requesterAddress;
+        await iexec.order
+          .signApporder(emptyAppOrder)
+          .then((o) => iexec.order.publishApporder(o));
+        // reset to empty
+        emptyAppOrder.requesterrestrict = NULL_ADDRESS;
+
+        // all orders (1,2,3,4,5)
+        const allAppOrders = await iexecReadOnly.orderbook.fetchAppOrderbook(
+          appAddress,
+          {
+            dataset: 'any',
+            requester: 'any',
+            workerpool: 'any',
+          },
+        );
+        expect(allAppOrders.count).toBe(5);
+        expect(allAppOrders.orders.length).toBe(5);
+
+        // all orders without restrictions (1, 2)
+        const unrestrictedAppOrders =
+          await iexecReadOnly.orderbook.fetchAppOrderbook(appAddress);
+        expect(unrestrictedAppOrders.count).toBe(2);
+        expect(unrestrictedAppOrders.orders.length).toBe(2);
+        expect(unrestrictedAppOrders.orders[0].order.datasetrestrict).toEqual(
+          NULL_ADDRESS,
+        );
+        expect(
+          unrestrictedAppOrders.orders[0].order.workerpoolrestrict,
+        ).toEqual(NULL_ADDRESS);
+        expect(unrestrictedAppOrders.orders[0].order.requesterrestrict).toEqual(
+          NULL_ADDRESS,
+        );
+        expect(unrestrictedAppOrders.orders[1].order.datasetrestrict).toEqual(
+          NULL_ADDRESS,
+        );
+        expect(
+          unrestrictedAppOrders.orders[0].order.workerpoolrestrict,
+        ).toEqual(NULL_ADDRESS);
+        expect(unrestrictedAppOrders.orders[0].order.requesterrestrict).toEqual(
+          NULL_ADDRESS,
+        );
+
+        // all orders without dataset restriction(1,2) and with dataset restriction(3)
+        const datasetRestrictedAppOrders =
+          await iexecReadOnly.orderbook.fetchAppOrderbook(appAddress, {
+            dataset: datasetAddress,
+          });
+        expect(datasetRestrictedAppOrders.count).toBe(3);
+        expect(datasetRestrictedAppOrders.orders.length).toBe(3);
+
+        // all orders with dataset restriction and strict(3)
+        const datasetStrictAppOrder =
+          await iexecReadOnly.orderbook.fetchAppOrderbook(appAddress, {
+            dataset: datasetAddress,
+            isDatasetStrict: true,
+          });
+        expect(datasetStrictAppOrder.count).toBe(1);
+        expect(datasetStrictAppOrder.orders.length).toBe(1);
+        expect(datasetStrictAppOrder.orders[0].order.datasetrestrict).toEqual(
+          datasetAddress,
+        );
+
+        // all orders without workerpool restriction(1,2) and with workerpool restriction(4)
+        const workerpoolRestrictedAppOrders =
+          await iexecReadOnly.orderbook.fetchAppOrderbook(appAddress, {
+            workerpool: workerpoolAddress,
+          });
+        expect(workerpoolRestrictedAppOrders.count).toBe(3);
+        expect(workerpoolRestrictedAppOrders.orders.length).toBe(3);
+
+        // all orders with workerpool restriction and strict(4)
+        const workerpoolStrictAppOrder =
+          await iexecReadOnly.orderbook.fetchAppOrderbook(appAddress, {
+            workerpool: workerpoolAddress,
+            isWorkerpoolStrict: true,
+          });
+        expect(workerpoolStrictAppOrder.count).toBe(1);
+        expect(workerpoolStrictAppOrder.orders.length).toBe(1);
+        expect(
+          workerpoolStrictAppOrder.orders[0].order.workerpoolrestrict,
+        ).toEqual(workerpoolAddress);
+
+        // all orders without requester restriction(1,2) and with requester restriction(5)
+        const requesterRestrictedAppOrders =
+          await iexecReadOnly.orderbook.fetchAppOrderbook(appAddress, {
+            requester: requesterAddress,
+          });
+        expect(requesterRestrictedAppOrders.count).toBe(3);
+        expect(requesterRestrictedAppOrders.orders.length).toBe(3);
+
+        // all orders with requester restriction and strict(5)
+        const requesterStrictAppOrders =
+          await iexecReadOnly.orderbook.fetchAppOrderbook(appAddress, {
+            requester: requesterAddress,
+            isRequesterStrict: true,
+          });
+        expect(requesterStrictAppOrders.count).toBe(1);
+        expect(requesterStrictAppOrders.orders.length).toBe(1);
+        expect(
+          requesterStrictAppOrders.orders[0].order.requesterrestrict,
+        ).toEqual(requesterAddress);
+
+        // all orders with requester, dataset, workerpool restriction and not strict (1,2,3,4,5)
+        const unstrictAppOrders =
+          await iexecReadOnly.orderbook.fetchAppOrderbook(appAddress, {
+            dataset: datasetAddress,
+            isDatasetStrict: false,
+            requester: requesterAddress,
+            isRequesterStrict: false,
+            workerpool: workerpoolAddress,
+            isWorkerpoolStrict: false,
+          });
+        expect(unstrictAppOrders.count).toBe(5);
+        expect(unstrictAppOrders.orders.length).toBe(5);
+
+        // all orders with requester, dataset, workerpool restriction and strict
+        const strictAppOrders = await iexecReadOnly.orderbook.fetchAppOrderbook(
+          appAddress,
+          {
+            dataset: datasetAddress,
+            isDatasetStrict: true,
+            requester: requesterAddress,
+            isRequesterStrict: true,
+            workerpool: workerpoolAddress,
+            isWorkerpoolStrict: true,
+          },
+        );
+        expect(strictAppOrders.count).toBe(0);
+        expect(strictAppOrders.orders.length).toBe(0);
+      });
     });
-  });
 
-  describe('fetchAppOrderbook()', () => {
-    test('returns orders available fo anyone', async () => {
-      const { iexec } = getTestConfig(iexecTestChain)();
-      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
-        readOnly: true,
+    describe('fetchDatasetOrderbook()', () => {
+      test('returns orders available fo anyone', async () => {
+        const { iexec } = getTestConfig(iexecTestChain)();
+        const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+          readOnly: true,
+        });
+        const datasetAddress = getRandomAddress();
+        const res =
+          await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress);
+        expect(res.count).toBe(0);
+        expect(res.orders).toStrictEqual([]);
+        const datasetorder = await deployAndGetDatasetorder(iexec);
+        for (let i = 0; i < 23; i += 1) {
+          await iexec.order
+            .signDatasetorder(datasetorder, { preflightCheck: false })
+            .then((o) =>
+              iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+            );
+        }
+        for (let i = 0; i < 2; i += 1) {
+          await iexec.order
+            .signDatasetorder(
+              { ...datasetorder, apprestrict: getRandomAddress() },
+              { preflightCheck: false },
+            )
+            .then((o) =>
+              iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+            );
+        }
+        for (let i = 0; i < 3; i += 1) {
+          await iexec.order
+            .signDatasetorder(
+              { ...datasetorder, workerpoolrestrict: getRandomAddress() },
+              { preflightCheck: false },
+            )
+            .then((o) =>
+              iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+            );
+        }
+        for (let i = 0; i < 4; i += 1) {
+          await iexec.order
+            .signDatasetorder(
+              { ...datasetorder, requesterrestrict: getRandomAddress() },
+              { preflightCheck: false },
+            )
+            .then((o) =>
+              iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+            );
+        }
+        await deployAndGetDatasetorder(iexec).then((o) =>
+          iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+        );
+
+        const res1 = await iexecReadOnly.orderbook.fetchDatasetOrderbook(
+          datasetorder.dataset,
+        );
+        expect(res1.count).toBe(23);
+        expect(res1.orders.length).toBe(20);
+        expect(res1.more).toBeDefined();
+        const res2 = await res1.more();
+        expect(res2.count).toBe(23);
+        expect(res2.orders.length).toBe(3);
+        expect(res2.more).toBeUndefined();
+        const res3 = await iexecReadOnly.orderbook.fetchDatasetOrderbook(
+          datasetorder.dataset,
+          { app: 'any' },
+        );
+        expect(res3.count).toBe(25);
+        const res4 = await iexecReadOnly.orderbook.fetchDatasetOrderbook(
+          datasetorder.dataset,
+          { workerpool: 'any' },
+        );
+        expect(res4.count).toBe(26);
+        const res5 = await iexecReadOnly.orderbook.fetchDatasetOrderbook(
+          datasetorder.dataset,
+          { requester: 'any' },
+        );
+        expect(res5.count).toBe(27);
+        const res6 = await iexecReadOnly.orderbook.fetchDatasetOrderbook(
+          datasetorder.dataset,
+          { app: 'any', workerpool: 'any', requester: 'any' },
+        );
+        expect(res6.count).toBe(32);
+        const res7 = await iexecReadOnly.orderbook.fetchDatasetOrderbook(
+          'any',
+          {
+            app: 'any',
+            requester: 'any',
+            workerpool: 'any',
+          },
+        );
+        expect(res7.count >= 33).toBe(true);
       });
-      const appAddress = getRandomAddress();
-      const res = await iexec.orderbook.fetchAppOrderbook(appAddress);
-      expect(res.count).toBe(0);
-      expect(res.orders).toStrictEqual([]);
-      const apporder = await deployAndGetApporder(iexec);
 
-      for (let i = 0; i < 22; i += 1) {
+      test('strict option allow filtering only orders for specified app, workerpool or requester', async () => {
+        const { iexec } = getTestConfig(iexecTestChain)();
+        const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+          readOnly: true,
+        });
+        // 1 and 2: orders without any restrictions
+        const emptyDatasetOrder = await deployAndGetDatasetorder(iexec);
+        const datasetAddress = emptyDatasetOrder.dataset;
+
+        await iexec.order
+          .signDatasetorder(emptyDatasetOrder, { preflightCheck: false })
+          .then((o) =>
+            iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+          );
+        await iexec.order
+          .signDatasetorder(emptyDatasetOrder, { preflightCheck: false })
+          .then((o) =>
+            iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+          );
+
+        // 3: app restricted order
+        const appAddress = getRandomAddress();
+        emptyDatasetOrder.apprestrict = appAddress;
+        await iexec.order
+          .signDatasetorder(emptyDatasetOrder, { preflightCheck: false })
+          .then((o) =>
+            iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+          );
+        // reset to empty
+        emptyDatasetOrder.apprestrict = NULL_ADDRESS;
+
+        // 4: workerpool restricted order
+        const workerpoolAddress = getRandomAddress();
+        emptyDatasetOrder.workerpoolrestrict = workerpoolAddress;
+        await iexec.order
+          .signDatasetorder(emptyDatasetOrder, { preflightCheck: false })
+          .then((o) =>
+            iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+          );
+        // reset to empty
+        emptyDatasetOrder.workerpoolrestrict = NULL_ADDRESS;
+
+        // 5: requester restricted order
+        const requesterAddress = getRandomAddress();
+        emptyDatasetOrder.requesterrestrict = requesterAddress;
+        await iexec.order
+          .signDatasetorder(emptyDatasetOrder, { preflightCheck: false })
+          .then((o) =>
+            iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+          );
+        // reset to empty
+        emptyDatasetOrder.requesterrestrict = NULL_ADDRESS;
+
+        // all orders (1,2,3,4,5)
+        const allADatasetOrders =
+          await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
+            app: 'any',
+            requester: 'any',
+            workerpool: 'any',
+          });
+        expect(allADatasetOrders.count).toBe(5);
+        expect(allADatasetOrders.orders.length).toBe(5);
+
+        // all orders without restrictions (1, 2)
+        const unrestrictedDatasetOrders =
+          await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress);
+        expect(unrestrictedDatasetOrders.count).toBe(2);
+        expect(unrestrictedDatasetOrders.orders.length).toBe(2);
+        expect(unrestrictedDatasetOrders.orders[0].order.apprestrict).toEqual(
+          NULL_ADDRESS,
+        );
+        expect(
+          unrestrictedDatasetOrders.orders[0].order.workerpoolrestrict,
+        ).toEqual(NULL_ADDRESS);
+        expect(
+          unrestrictedDatasetOrders.orders[0].order.requesterrestrict,
+        ).toEqual(NULL_ADDRESS);
+        expect(unrestrictedDatasetOrders.orders[1].order.apprestrict).toEqual(
+          NULL_ADDRESS,
+        );
+        expect(
+          unrestrictedDatasetOrders.orders[0].order.workerpoolrestrict,
+        ).toEqual(NULL_ADDRESS);
+        expect(
+          unrestrictedDatasetOrders.orders[0].order.requesterrestrict,
+        ).toEqual(NULL_ADDRESS);
+
+        // all orders without app restriction(1,2) and with app restriction(3)
+        const appRestrictedAppOrders =
+          await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
+            app: appAddress,
+          });
+        expect(appRestrictedAppOrders.count).toBe(3);
+        expect(appRestrictedAppOrders.orders.length).toBe(3);
+
+        // all orders with app restriction and strict(3)
+        const appStrictAppOrder =
+          await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
+            app: appAddress,
+            isAppStrict: true,
+          });
+        expect(appStrictAppOrder.count).toBe(1);
+        expect(appStrictAppOrder.orders.length).toBe(1);
+        expect(appStrictAppOrder.orders[0].order.apprestrict).toEqual(
+          appAddress,
+        );
+
+        // all orders without workerpool restriction(1,2) and with workerpool restriction(4)
+        const workerpoolRestrictedAppOrders =
+          await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
+            workerpool: workerpoolAddress,
+          });
+        expect(workerpoolRestrictedAppOrders.count).toBe(3);
+        expect(workerpoolRestrictedAppOrders.orders.length).toBe(3);
+
+        // all orders with workerpool restriction and strict(4)
+        const workerpoolStrictAppOrder =
+          await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
+            workerpool: workerpoolAddress,
+            isWorkerpoolStrict: true,
+          });
+        expect(workerpoolStrictAppOrder.count).toBe(1);
+        expect(workerpoolStrictAppOrder.orders.length).toBe(1);
+        expect(
+          workerpoolStrictAppOrder.orders[0].order.workerpoolrestrict,
+        ).toEqual(workerpoolAddress);
+
+        // all orders without requester restriction(1,2) and with requester restriction(5)
+        const requesterRestrictedAppOrders =
+          await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
+            requester: requesterAddress,
+          });
+        expect(requesterRestrictedAppOrders.count).toBe(3);
+        expect(requesterRestrictedAppOrders.orders.length).toBe(3);
+
+        // all orders with requester restriction and strict(5)
+        const requesterStrictAppOrders =
+          await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
+            requester: requesterAddress,
+            isRequesterStrict: true,
+          });
+        expect(requesterStrictAppOrders.count).toBe(1);
+        expect(requesterStrictAppOrders.orders.length).toBe(1);
+        expect(
+          requesterStrictAppOrders.orders[0].order.requesterrestrict,
+        ).toEqual(requesterAddress);
+
+        // all orders with app, requester, workerpool restriction and not strict (1,2,3,4,5)
+        const unstrictAppOrders =
+          await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
+            app: appAddress,
+            isAppStrict: false,
+            requester: requesterAddress,
+            isRequesterStrict: false,
+            workerpool: workerpoolAddress,
+            isWorkerpoolStrict: false,
+          });
+        expect(unstrictAppOrders.count).toBe(5);
+        expect(unstrictAppOrders.orders.length).toBe(5);
+
+        // all orders with app, requester, workerpool restriction and strict
+        const strictAppOrders =
+          await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
+            app: appAddress,
+            isAppStrict: true,
+            requester: requesterAddress,
+            isRequesterStrict: true,
+            workerpool: workerpoolAddress,
+            isWorkerpoolStrict: true,
+          });
+        expect(strictAppOrders.count).toBe(0);
+        expect(strictAppOrders.orders.length).toBe(0);
+      });
+    });
+
+    describe('fetchWorkerpoolOrderbook()', () => {
+      test('returns orders available fo anyone', async () => {
+        const { iexec } = getTestConfig(iexecTestChain)();
+        const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+          readOnly: true,
+        });
+        const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
+        const res = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+          workerpool: workerpoolorder.workerpool,
+          category: 2,
+        });
+        expect(res.count).toBe(0);
+        expect(res.orders).toStrictEqual([]);
+        for (let i = 0; i < 24; i += 1) {
+          await iexec.order
+            .signWorkerpoolorder(workerpoolorder)
+            .then((o) => iexec.order.publishWorkerpoolorder(o));
+        }
+        for (let i = 0; i < 2; i += 1) {
+          await iexec.order
+            .signWorkerpoolorder({
+              ...workerpoolorder,
+              apprestrict: getRandomAddress(),
+            })
+            .then((o) => iexec.order.publishWorkerpoolorder(o));
+        }
+        for (let i = 0; i < 3; i += 1) {
+          await iexec.order
+            .signWorkerpoolorder({
+              ...workerpoolorder,
+              datasetrestrict: getRandomAddress(),
+            })
+            .then((o) => iexec.order.publishWorkerpoolorder(o));
+        }
+        for (let i = 0; i < 4; i += 1) {
+          await iexec.order
+            .signWorkerpoolorder({
+              ...workerpoolorder,
+              requesterrestrict: getRandomAddress(),
+            })
+            .then((o) => iexec.order.publishWorkerpoolorder(o));
+        }
+        const res1 = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+          workerpool: workerpoolorder.workerpool,
+        });
+        expect(res1.count).toBe(24);
+        expect(res1.orders.length).toBe(20);
+        expect(res1.more).toBeDefined();
+        const res2 = await res1.more();
+        expect(res2.count).toBe(24);
+        expect(res2.orders.length).toBe(4);
+        expect(res2.more).toBeUndefined();
+        const res3 = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+          workerpool: workerpoolorder.workerpool,
+          app: 'any',
+        });
+        expect(res3.count).toBe(26);
+        const res4 = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+          workerpool: workerpoolorder.workerpool,
+          dataset: 'any',
+        });
+        expect(res4.count).toBe(27);
+        const res5 = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+          workerpool: workerpoolorder.workerpool,
+          requester: 'any',
+        });
+        expect(res5.count).toBe(28);
+        const res6 = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+          workerpool: workerpoolorder.workerpool,
+          app: 'any',
+          dataset: 'any',
+          requester: 'any',
+        });
+        expect(res6.count).toBe(33);
+        const res7 = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+          app: 'any',
+          dataset: 'any',
+          requester: 'any',
+        });
+        const res8 = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+          workerpool: 'any',
+          app: 'any',
+          dataset: 'any',
+          requester: 'any',
+        });
+        expect(res7.count).toBe(res8.count);
+      });
+
+      test('strict option allow filtering only orders for specified app, dataset or requester', async () => {
+        const { iexec } = getTestConfig(iexecTestChain)();
+        const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+          readOnly: true,
+        });
+        // 1 and 2: orders without any restrictions
+        const emptyWorkerpoolOrder = await deployAndGetWorkerpoolorder(iexec);
+        const workerpoolAddress = emptyWorkerpoolOrder.workerpool;
+        await iexec.order
+          .signWorkerpoolorder(emptyWorkerpoolOrder)
+          .then((o) => iexec.order.publishWorkerpoolorder(o));
+        await iexec.order
+          .signWorkerpoolorder(emptyWorkerpoolOrder)
+          .then((o) => iexec.order.publishWorkerpoolorder(o));
+
+        // 3: app restricted order
+        const appAddress = getRandomAddress();
+        emptyWorkerpoolOrder.apprestrict = appAddress;
+        await iexec.order
+          .signWorkerpoolorder(emptyWorkerpoolOrder)
+          .then((o) => iexec.order.publishWorkerpoolorder(o));
+        // reset to empty
+        emptyWorkerpoolOrder.apprestrict = NULL_ADDRESS;
+
+        // 4: dataset restricted order
+        const datasetAddress = getRandomAddress();
+        emptyWorkerpoolOrder.datasetrestrict = datasetAddress;
+        await iexec.order
+          .signWorkerpoolorder(emptyWorkerpoolOrder)
+          .then((o) => iexec.order.publishWorkerpoolorder(o));
+        // reset to empty
+        emptyWorkerpoolOrder.datasetrestrict = NULL_ADDRESS;
+
+        // 5: requester restricted order
+        const requesterAddress = getRandomAddress();
+        emptyWorkerpoolOrder.requesterrestrict = requesterAddress;
+        await iexec.order
+          .signWorkerpoolorder(emptyWorkerpoolOrder)
+          .then((o) => iexec.order.publishWorkerpoolorder(o));
+        // reset to empty
+        emptyWorkerpoolOrder.requesterrestrict = NULL_ADDRESS;
+
+        // all orders (1,2,3,4,5)
+        const allWorkerpoolOrders =
+          await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+            workerpool: workerpoolAddress,
+            app: 'any',
+            requester: 'any',
+            dataset: 'any',
+          });
+
+        expect(allWorkerpoolOrders.count).toBe(5);
+        expect(allWorkerpoolOrders.orders.length).toBe(5);
+
+        // all orders without restrictions (1, 2)
+        const unrestrictedWorkerpoolOrders =
+          await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+            workerpool: workerpoolAddress,
+          });
+        expect(unrestrictedWorkerpoolOrders.count).toBe(2);
+        expect(unrestrictedWorkerpoolOrders.orders.length).toBe(2);
+        expect(
+          unrestrictedWorkerpoolOrders.orders[0].order.apprestrict,
+        ).toEqual(NULL_ADDRESS);
+        expect(
+          unrestrictedWorkerpoolOrders.orders[0].order.datasetrestrict,
+        ).toEqual(NULL_ADDRESS);
+        expect(
+          unrestrictedWorkerpoolOrders.orders[0].order.requesterrestrict,
+        ).toEqual(NULL_ADDRESS);
+        expect(
+          unrestrictedWorkerpoolOrders.orders[1].order.apprestrict,
+        ).toEqual(NULL_ADDRESS);
+        expect(
+          unrestrictedWorkerpoolOrders.orders[0].order.datasetrestrict,
+        ).toEqual(NULL_ADDRESS);
+        expect(
+          unrestrictedWorkerpoolOrders.orders[0].order.requesterrestrict,
+        ).toEqual(NULL_ADDRESS);
+
+        // all orders without app restriction(1,2) and with app restriction(3)
+        const appRestrictedAppOrders =
+          await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+            workerpool: workerpoolAddress,
+            app: appAddress,
+          });
+        expect(appRestrictedAppOrders.count).toBe(3);
+        expect(appRestrictedAppOrders.orders.length).toBe(3);
+
+        // all orders with app restriction and strict(3)
+        const appStrictAppOrder =
+          await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+            workerpool: workerpoolAddress,
+            app: appAddress,
+            isAppStrict: true,
+          });
+        expect(appStrictAppOrder.count).toBe(1);
+        expect(appStrictAppOrder.orders.length).toBe(1);
+        expect(appStrictAppOrder.orders[0].order.apprestrict).toEqual(
+          appAddress,
+        );
+
+        // all orders without dataset restriction(1,2) and with dataset restriction(4)
+        const datasetRestrictedWorkerpoolOrders =
+          await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+            workerpool: workerpoolAddress,
+            dataset: datasetAddress,
+          });
+        expect(datasetRestrictedWorkerpoolOrders.count).toBe(3);
+        expect(datasetRestrictedWorkerpoolOrders.orders.length).toBe(3);
+
+        // all orders with dataset restriction and strict(4)
+        const datasetStrictAppOrder =
+          await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+            workerpool: workerpoolAddress,
+            dataset: datasetAddress,
+            isDatasetStrict: true,
+          });
+        expect(datasetStrictAppOrder.count).toBe(1);
+        expect(datasetStrictAppOrder.orders.length).toBe(1);
+        expect(datasetStrictAppOrder.orders[0].order.datasetrestrict).toEqual(
+          datasetAddress,
+        );
+
+        // all orders without requester restriction(1,2) and with requester restriction(5)
+        const requesterRestrictedAppOrders =
+          await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+            workerpool: workerpoolAddress,
+            requester: requesterAddress,
+          });
+        expect(requesterRestrictedAppOrders.count).toBe(3);
+        expect(requesterRestrictedAppOrders.orders.length).toBe(3);
+
+        // all orders with requester restriction and strict(5)
+        const requesterStrictAppOrders =
+          await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+            workerpool: workerpoolAddress,
+            requester: requesterAddress,
+            isRequesterStrict: true,
+          });
+        expect(requesterStrictAppOrders.count).toBe(1);
+        expect(requesterStrictAppOrders.orders.length).toBe(1);
+        expect(
+          requesterStrictAppOrders.orders[0].order.requesterrestrict,
+        ).toEqual(requesterAddress);
+
+        // all orders with requester, dataset, workerpool restriction and not strict (1,2,3,4,5)
+        const unstrictAppOrders =
+          await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+            workerpool: workerpoolAddress,
+            app: appAddress,
+            isAppStrict: false,
+            requester: requesterAddress,
+            isRequesterStrict: false,
+            dataset: datasetAddress,
+            isDatasetStrict: false,
+          });
+        expect(unstrictAppOrders.count).toBe(5);
+        expect(unstrictAppOrders.orders.length).toBe(5);
+
+        // all orders with requester, dataset, workerpool restriction and strict
+        const strictAppOrders =
+          await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
+            workerpool: workerpoolAddress,
+            app: appAddress,
+            isAppStrict: true,
+            requester: requesterAddress,
+            isRequesterStrict: true,
+            dataset: datasetAddress,
+            isDatasetStrict: true,
+          });
+        expect(strictAppOrders.count).toBe(0);
+        expect(strictAppOrders.orders.length).toBe(0);
+      });
+    });
+
+    describe('fetchRequestOrderbook()', () => {
+      test('returns orders available fo anyone', async () => {
+        const { iexec, wallet } = getTestConfig(iexecTestChain)();
+        const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+          readOnly: true,
+        });
+        const apporder = await deployAndGetApporder(iexec);
+        const workerpoolorder = await deployAndGetWorkerpoolorder(iexec, {
+          category: 2,
+        });
+        const requestorder = await getMatchableRequestorder(iexec, {
+          apporder,
+          workerpoolorder,
+        });
+        await iexec.order.publishApporder(apporder);
+        await iexec.order.publishWorkerpoolorder(workerpoolorder);
+        for (let i = 0; i < 25; i += 1) {
+          await iexec.order
+            .signRequestorder(
+              { ...requestorder, workerpool: NULL_ADDRESS },
+              { preflightCheck: false },
+            )
+            .then((o) =>
+              iexec.order.publishRequestorder(o, {
+                preflightCheck: false,
+              }),
+            );
+        }
+        for (let i = 0; i < 2; i += 1) {
+          await iexec.order
+            .signRequestorder(
+              { ...requestorder, workerpool: getRandomAddress() },
+              { preflightCheck: false },
+            )
+            .then((o) =>
+              iexec.order.publishRequestorder(o, {
+                preflightCheck: false,
+              }),
+            );
+        }
+        const res1 = await iexecReadOnly.orderbook.fetchRequestOrderbook({
+          requester: wallet.address,
+          category: 2,
+        });
+        expect(res1.count).toBe(25);
+        expect(res1.orders.length).toBe(20);
+        expect(res1.more).toBeDefined();
+        const res2 = await res1.more();
+        expect(res2.count).toBe(25);
+        expect(res2.orders.length >= 5).toBe(true);
+        if (res2.orders.length < 20) {
+          expect(res2.more).toBeUndefined();
+        }
+        const res3 = await iexecReadOnly.orderbook.fetchRequestOrderbook({
+          requester: wallet.address,
+          category: 2,
+          workerpool: 'any',
+        });
+        expect(res3.count).toBe(27);
+        const res4 = await iexecReadOnly.orderbook.fetchRequestOrderbook({
+          workerpool: 'any',
+        });
+        const res5 = await iexecReadOnly.orderbook.fetchRequestOrderbook({
+          requester: 'any',
+          workerpool: 'any',
+        });
+        expect(res4.count).toBe(res5.count);
+      });
+
+      test('strict option allow filtering only orders for specified workerpool', async () => {
+        const { iexec, wallet } = getTestConfig(iexecTestChain)();
+        const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+          readOnly: true,
+        });
+        const requesterAddress = wallet.address;
+
+        const apporder = await deployAndGetApporder(iexec);
+        const appAddress = apporder.app;
         await iexec.order
           .signApporder(apporder)
           .then((o) => iexec.order.publishApporder(o));
-      }
-      for (let i = 0; i < 2; i += 1) {
+
+        const datasetorder = await deployAndGetDatasetorder(iexec);
+        const datasetAddress = datasetorder.dataset;
         await iexec.order
-          .signApporder({ ...apporder, datasetrestrict: getRandomAddress() })
-          .then((o) => iexec.order.publishApporder(o));
-      }
-      for (let i = 0; i < 3; i += 1) {
-        await iexec.order
-          .signApporder({ ...apporder, workerpoolrestrict: getRandomAddress() })
-          .then((o) => iexec.order.publishApporder(o));
-      }
-      for (let i = 0; i < 4; i += 1) {
-        await iexec.order
-          .signApporder({ ...apporder, requesterrestrict: getRandomAddress() })
-          .then((o) => iexec.order.publishApporder(o));
-      }
-      await deployAndGetApporder(iexec).then((o) =>
-        iexec.order.publishApporder(o),
-      );
-
-      const res1 = await iexecReadOnly.orderbook.fetchAppOrderbook(
-        apporder.app,
-      );
-      expect(res1.count).toBe(22);
-      expect(res1.orders.length).toBe(20);
-      expect(res1.more).toBeDefined();
-      const res2 = await res1.more();
-      expect(res2.count).toBe(22);
-      expect(res2.orders.length).toBe(2);
-      expect(res2.more).toBeUndefined();
-      const res3 = await iexecReadOnly.orderbook.fetchAppOrderbook(
-        apporder.app,
-        {
-          dataset: 'any',
-        },
-      );
-      expect(res3.count).toBe(24);
-      const res4 = await iexecReadOnly.orderbook.fetchAppOrderbook(
-        apporder.app,
-        {
-          workerpool: 'any',
-        },
-      );
-      expect(res4.count).toBe(25);
-      const res5 = await iexecReadOnly.orderbook.fetchAppOrderbook(
-        apporder.app,
-        {
-          requester: 'any',
-        },
-      );
-      expect(res5.count).toBe(26);
-      const res6 = await iexecReadOnly.orderbook.fetchAppOrderbook(
-        apporder.app,
-        {
-          dataset: 'any',
-          requester: 'any',
-          workerpool: 'any',
-        },
-      );
-      expect(res6.count).toBe(31);
-      const res7 = await iexecReadOnly.orderbook.fetchAppOrderbook('any', {
-        dataset: 'any',
-        requester: 'any',
-        workerpool: 'any',
-      });
-      expect(res7.count >= 32).toBe(true);
-    });
-
-    test('strict option allow filtering only orders for specified dataset, workerpool or requester', async () => {
-      const { iexec } = getTestConfig(iexecTestChain)();
-      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
-        readOnly: true,
-      });
-
-      // 1 and 2: orders without any restrictions
-      const emptyAppOrder = await deployAndGetApporder(iexec);
-      const appAddress = emptyAppOrder.app;
-
-      await iexec.order
-        .signApporder(emptyAppOrder)
-        .then((o) => iexec.order.publishApporder(o));
-      await iexec.order
-        .signApporder(emptyAppOrder)
-        .then((o) => iexec.order.publishApporder(o));
-
-      // 3: dataset restricted order
-      const datasetAddress = getRandomAddress();
-      emptyAppOrder.datasetrestrict = datasetAddress;
-      await iexec.order
-        .signApporder(emptyAppOrder)
-        .then((o) => iexec.order.publishApporder(o));
-      // reset to empty
-      emptyAppOrder.datasetrestrict = NULL_ADDRESS;
-
-      // 4: workerpool restricted order
-      const workerpoolAddress = getRandomAddress();
-      emptyAppOrder.workerpoolrestrict = workerpoolAddress;
-      await iexec.order
-        .signApporder(emptyAppOrder)
-        .then((o) => iexec.order.publishApporder(o));
-      // reset to empty
-      emptyAppOrder.workerpoolrestrict = NULL_ADDRESS;
-
-      // 5: requester restricted order
-      const requesterAddress = getRandomAddress();
-      emptyAppOrder.requesterrestrict = requesterAddress;
-      await iexec.order
-        .signApporder(emptyAppOrder)
-        .then((o) => iexec.order.publishApporder(o));
-      // reset to empty
-      emptyAppOrder.requesterrestrict = NULL_ADDRESS;
-
-      // all orders (1,2,3,4,5)
-      const allAppOrders = await iexecReadOnly.orderbook.fetchAppOrderbook(
-        appAddress,
-        {
-          dataset: 'any',
-          requester: 'any',
-          workerpool: 'any',
-        },
-      );
-      expect(allAppOrders.count).toBe(5);
-      expect(allAppOrders.orders.length).toBe(5);
-
-      // all orders without restrictions (1, 2)
-      const unrestrictedAppOrders =
-        await iexecReadOnly.orderbook.fetchAppOrderbook(appAddress);
-      expect(unrestrictedAppOrders.count).toBe(2);
-      expect(unrestrictedAppOrders.orders.length).toBe(2);
-      expect(unrestrictedAppOrders.orders[0].order.datasetrestrict).toEqual(
-        NULL_ADDRESS,
-      );
-      expect(unrestrictedAppOrders.orders[0].order.workerpoolrestrict).toEqual(
-        NULL_ADDRESS,
-      );
-      expect(unrestrictedAppOrders.orders[0].order.requesterrestrict).toEqual(
-        NULL_ADDRESS,
-      );
-      expect(unrestrictedAppOrders.orders[1].order.datasetrestrict).toEqual(
-        NULL_ADDRESS,
-      );
-      expect(unrestrictedAppOrders.orders[0].order.workerpoolrestrict).toEqual(
-        NULL_ADDRESS,
-      );
-      expect(unrestrictedAppOrders.orders[0].order.requesterrestrict).toEqual(
-        NULL_ADDRESS,
-      );
-
-      // all orders without dataset restriction(1,2) and with dataset restriction(3)
-      const datasetRestrictedAppOrders =
-        await iexecReadOnly.orderbook.fetchAppOrderbook(appAddress, {
-          dataset: datasetAddress,
-        });
-      expect(datasetRestrictedAppOrders.count).toBe(3);
-      expect(datasetRestrictedAppOrders.orders.length).toBe(3);
-
-      // all orders with dataset restriction and strict(3)
-      const datasetStrictAppOrder =
-        await iexecReadOnly.orderbook.fetchAppOrderbook(appAddress, {
-          dataset: datasetAddress,
-          isDatasetStrict: true,
-        });
-      expect(datasetStrictAppOrder.count).toBe(1);
-      expect(datasetStrictAppOrder.orders.length).toBe(1);
-      expect(datasetStrictAppOrder.orders[0].order.datasetrestrict).toEqual(
-        datasetAddress,
-      );
-
-      // all orders without workerpool restriction(1,2) and with workerpool restriction(4)
-      const workerpoolRestrictedAppOrders =
-        await iexecReadOnly.orderbook.fetchAppOrderbook(appAddress, {
-          workerpool: workerpoolAddress,
-        });
-      expect(workerpoolRestrictedAppOrders.count).toBe(3);
-      expect(workerpoolRestrictedAppOrders.orders.length).toBe(3);
-
-      // all orders with workerpool restriction and strict(4)
-      const workerpoolStrictAppOrder =
-        await iexecReadOnly.orderbook.fetchAppOrderbook(appAddress, {
-          workerpool: workerpoolAddress,
-          isWorkerpoolStrict: true,
-        });
-      expect(workerpoolStrictAppOrder.count).toBe(1);
-      expect(workerpoolStrictAppOrder.orders.length).toBe(1);
-      expect(
-        workerpoolStrictAppOrder.orders[0].order.workerpoolrestrict,
-      ).toEqual(workerpoolAddress);
-
-      // all orders without requester restriction(1,2) and with requester restriction(5)
-      const requesterRestrictedAppOrders =
-        await iexecReadOnly.orderbook.fetchAppOrderbook(appAddress, {
-          requester: requesterAddress,
-        });
-      expect(requesterRestrictedAppOrders.count).toBe(3);
-      expect(requesterRestrictedAppOrders.orders.length).toBe(3);
-
-      // all orders with requester restriction and strict(5)
-      const requesterStrictAppOrders =
-        await iexecReadOnly.orderbook.fetchAppOrderbook(appAddress, {
-          requester: requesterAddress,
-          isRequesterStrict: true,
-        });
-      expect(requesterStrictAppOrders.count).toBe(1);
-      expect(requesterStrictAppOrders.orders.length).toBe(1);
-      expect(
-        requesterStrictAppOrders.orders[0].order.requesterrestrict,
-      ).toEqual(requesterAddress);
-
-      // all orders with requester, dataset, workerpool restriction and not strict (1,2,3,4,5)
-      const unstrictAppOrders = await iexecReadOnly.orderbook.fetchAppOrderbook(
-        appAddress,
-        {
-          dataset: datasetAddress,
-          isDatasetStrict: false,
-          requester: requesterAddress,
-          isRequesterStrict: false,
-          workerpool: workerpoolAddress,
-          isWorkerpoolStrict: false,
-        },
-      );
-      expect(unstrictAppOrders.count).toBe(5);
-      expect(unstrictAppOrders.orders.length).toBe(5);
-
-      // all orders with requester, dataset, workerpool restriction and strict
-      const strictAppOrders = await iexecReadOnly.orderbook.fetchAppOrderbook(
-        appAddress,
-        {
-          dataset: datasetAddress,
-          isDatasetStrict: true,
-          requester: requesterAddress,
-          isRequesterStrict: true,
-          workerpool: workerpoolAddress,
-          isWorkerpoolStrict: true,
-        },
-      );
-      expect(strictAppOrders.count).toBe(0);
-      expect(strictAppOrders.orders.length).toBe(0);
-    });
-  });
-
-  describe('fetchDatasetOrderbook()', () => {
-    test('returns orders available fo anyone', async () => {
-      const { iexec } = getTestConfig(iexecTestChain)();
-      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
-        readOnly: true,
-      });
-      const datasetAddress = getRandomAddress();
-      const res =
-        await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress);
-      expect(res.count).toBe(0);
-      expect(res.orders).toStrictEqual([]);
-      const datasetorder = await deployAndGetDatasetorder(iexec);
-      for (let i = 0; i < 23; i += 1) {
-        await iexec.order
-          .signDatasetorder(datasetorder, { preflightCheck: false })
+          .signDatasetorder(datasetorder)
           .then((o) =>
             iexec.order.publishDatasetorder(o, { preflightCheck: false }),
           );
-      }
-      for (let i = 0; i < 2; i += 1) {
-        await iexec.order
-          .signDatasetorder(
-            { ...datasetorder, apprestrict: getRandomAddress() },
-            { preflightCheck: false },
-          )
-          .then((o) =>
-            iexec.order.publishDatasetorder(o, { preflightCheck: false }),
-          );
-      }
-      for (let i = 0; i < 3; i += 1) {
-        await iexec.order
-          .signDatasetorder(
-            { ...datasetorder, workerpoolrestrict: getRandomAddress() },
-            { preflightCheck: false },
-          )
-          .then((o) =>
-            iexec.order.publishDatasetorder(o, { preflightCheck: false }),
-          );
-      }
-      for (let i = 0; i < 4; i += 1) {
-        await iexec.order
-          .signDatasetorder(
-            { ...datasetorder, requesterrestrict: getRandomAddress() },
-            { preflightCheck: false },
-          )
-          .then((o) =>
-            iexec.order.publishDatasetorder(o, { preflightCheck: false }),
-          );
-      }
-      await deployAndGetDatasetorder(iexec).then((o) =>
-        iexec.order.publishDatasetorder(o, { preflightCheck: false }),
-      );
 
-      const res1 = await iexecReadOnly.orderbook.fetchDatasetOrderbook(
-        datasetorder.dataset,
-      );
-      expect(res1.count).toBe(23);
-      expect(res1.orders.length).toBe(20);
-      expect(res1.more).toBeDefined();
-      const res2 = await res1.more();
-      expect(res2.count).toBe(23);
-      expect(res2.orders.length).toBe(3);
-      expect(res2.more).toBeUndefined();
-      const res3 = await iexecReadOnly.orderbook.fetchDatasetOrderbook(
-        datasetorder.dataset,
-        { app: 'any' },
-      );
-      expect(res3.count).toBe(25);
-      const res4 = await iexecReadOnly.orderbook.fetchDatasetOrderbook(
-        datasetorder.dataset,
-        { workerpool: 'any' },
-      );
-      expect(res4.count).toBe(26);
-      const res5 = await iexecReadOnly.orderbook.fetchDatasetOrderbook(
-        datasetorder.dataset,
-        { requester: 'any' },
-      );
-      expect(res5.count).toBe(27);
-      const res6 = await iexecReadOnly.orderbook.fetchDatasetOrderbook(
-        datasetorder.dataset,
-        { app: 'any', workerpool: 'any', requester: 'any' },
-      );
-      expect(res6.count).toBe(32);
-      const res7 = await iexecReadOnly.orderbook.fetchDatasetOrderbook('any', {
-        app: 'any',
-        requester: 'any',
-        workerpool: 'any',
-      });
-      expect(res7.count >= 33).toBe(true);
-    });
-
-    test('strict option allow filtering only orders for specified app, workerpool or requester', async () => {
-      const { iexec } = getTestConfig(iexecTestChain)();
-      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
-        readOnly: true,
-      });
-      // 1 and 2: orders without any restrictions
-      const emptyDatasetOrder = await deployAndGetDatasetorder(iexec);
-      const datasetAddress = emptyDatasetOrder.dataset;
-
-      await iexec.order
-        .signDatasetorder(emptyDatasetOrder, { preflightCheck: false })
-        .then((o) =>
-          iexec.order.publishDatasetorder(o, { preflightCheck: false }),
-        );
-      await iexec.order
-        .signDatasetorder(emptyDatasetOrder, { preflightCheck: false })
-        .then((o) =>
-          iexec.order.publishDatasetorder(o, { preflightCheck: false }),
-        );
-
-      // 3: app restricted order
-      const appAddress = getRandomAddress();
-      emptyDatasetOrder.apprestrict = appAddress;
-      await iexec.order
-        .signDatasetorder(emptyDatasetOrder, { preflightCheck: false })
-        .then((o) =>
-          iexec.order.publishDatasetorder(o, { preflightCheck: false }),
-        );
-      // reset to empty
-      emptyDatasetOrder.apprestrict = NULL_ADDRESS;
-
-      // 4: workerpool restricted order
-      const workerpoolAddress = getRandomAddress();
-      emptyDatasetOrder.workerpoolrestrict = workerpoolAddress;
-      await iexec.order
-        .signDatasetorder(emptyDatasetOrder, { preflightCheck: false })
-        .then((o) =>
-          iexec.order.publishDatasetorder(o, { preflightCheck: false }),
-        );
-      // reset to empty
-      emptyDatasetOrder.workerpoolrestrict = NULL_ADDRESS;
-
-      // 5: requester restricted order
-      const requesterAddress = getRandomAddress();
-      emptyDatasetOrder.requesterrestrict = requesterAddress;
-      await iexec.order
-        .signDatasetorder(emptyDatasetOrder, { preflightCheck: false })
-        .then((o) =>
-          iexec.order.publishDatasetorder(o, { preflightCheck: false }),
-        );
-      // reset to empty
-      emptyDatasetOrder.requesterrestrict = NULL_ADDRESS;
-
-      // all orders (1,2,3,4,5)
-      const allADatasetOrders =
-        await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
-          app: 'any',
-          requester: 'any',
-          workerpool: 'any',
-        });
-      expect(allADatasetOrders.count).toBe(5);
-      expect(allADatasetOrders.orders.length).toBe(5);
-
-      // all orders without restrictions (1, 2)
-      const unrestrictedDatasetOrders =
-        await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress);
-      expect(unrestrictedDatasetOrders.count).toBe(2);
-      expect(unrestrictedDatasetOrders.orders.length).toBe(2);
-      expect(unrestrictedDatasetOrders.orders[0].order.apprestrict).toEqual(
-        NULL_ADDRESS,
-      );
-      expect(
-        unrestrictedDatasetOrders.orders[0].order.workerpoolrestrict,
-      ).toEqual(NULL_ADDRESS);
-      expect(
-        unrestrictedDatasetOrders.orders[0].order.requesterrestrict,
-      ).toEqual(NULL_ADDRESS);
-      expect(unrestrictedDatasetOrders.orders[1].order.apprestrict).toEqual(
-        NULL_ADDRESS,
-      );
-      expect(
-        unrestrictedDatasetOrders.orders[0].order.workerpoolrestrict,
-      ).toEqual(NULL_ADDRESS);
-      expect(
-        unrestrictedDatasetOrders.orders[0].order.requesterrestrict,
-      ).toEqual(NULL_ADDRESS);
-
-      // all orders without app restriction(1,2) and with app restriction(3)
-      const appRestrictedAppOrders =
-        await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
-          app: appAddress,
-        });
-      expect(appRestrictedAppOrders.count).toBe(3);
-      expect(appRestrictedAppOrders.orders.length).toBe(3);
-
-      // all orders with app restriction and strict(3)
-      const appStrictAppOrder =
-        await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
-          app: appAddress,
-          isAppStrict: true,
-        });
-      expect(appStrictAppOrder.count).toBe(1);
-      expect(appStrictAppOrder.orders.length).toBe(1);
-      expect(appStrictAppOrder.orders[0].order.apprestrict).toEqual(appAddress);
-
-      // all orders without workerpool restriction(1,2) and with workerpool restriction(4)
-      const workerpoolRestrictedAppOrders =
-        await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
-          workerpool: workerpoolAddress,
-        });
-      expect(workerpoolRestrictedAppOrders.count).toBe(3);
-      expect(workerpoolRestrictedAppOrders.orders.length).toBe(3);
-
-      // all orders with workerpool restriction and strict(4)
-      const workerpoolStrictAppOrder =
-        await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
-          workerpool: workerpoolAddress,
-          isWorkerpoolStrict: true,
-        });
-      expect(workerpoolStrictAppOrder.count).toBe(1);
-      expect(workerpoolStrictAppOrder.orders.length).toBe(1);
-      expect(
-        workerpoolStrictAppOrder.orders[0].order.workerpoolrestrict,
-      ).toEqual(workerpoolAddress);
-
-      // all orders without requester restriction(1,2) and with requester restriction(5)
-      const requesterRestrictedAppOrders =
-        await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
-          requester: requesterAddress,
-        });
-      expect(requesterRestrictedAppOrders.count).toBe(3);
-      expect(requesterRestrictedAppOrders.orders.length).toBe(3);
-
-      // all orders with requester restriction and strict(5)
-      const requesterStrictAppOrders =
-        await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
-          requester: requesterAddress,
-          isRequesterStrict: true,
-        });
-      expect(requesterStrictAppOrders.count).toBe(1);
-      expect(requesterStrictAppOrders.orders.length).toBe(1);
-      expect(
-        requesterStrictAppOrders.orders[0].order.requesterrestrict,
-      ).toEqual(requesterAddress);
-
-      // all orders with app, requester, workerpool restriction and not strict (1,2,3,4,5)
-      const unstrictAppOrders =
-        await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
-          app: appAddress,
-          isAppStrict: false,
-          requester: requesterAddress,
-          isRequesterStrict: false,
-          workerpool: workerpoolAddress,
-          isWorkerpoolStrict: false,
-        });
-      expect(unstrictAppOrders.count).toBe(5);
-      expect(unstrictAppOrders.orders.length).toBe(5);
-
-      // all orders with app, requester, workerpool restriction and strict
-      const strictAppOrders =
-        await iexecReadOnly.orderbook.fetchDatasetOrderbook(datasetAddress, {
-          app: appAddress,
-          isAppStrict: true,
-          requester: requesterAddress,
-          isRequesterStrict: true,
-          workerpool: workerpoolAddress,
-          isWorkerpoolStrict: true,
-        });
-      expect(strictAppOrders.count).toBe(0);
-      expect(strictAppOrders.orders.length).toBe(0);
-    });
-  });
-
-  describe('fetchWorkerpoolOrderbook()', () => {
-    test('returns orders available fo anyone', async () => {
-      const { iexec } = getTestConfig(iexecTestChain)();
-      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
-        readOnly: true,
-      });
-      const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
-      const res = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-        workerpool: workerpoolorder.workerpool,
-        category: 2,
-      });
-      expect(res.count).toBe(0);
-      expect(res.orders).toStrictEqual([]);
-      for (let i = 0; i < 24; i += 1) {
+        const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
+        const workerpoolAddress = workerpoolorder.workerpool;
         await iexec.order
           .signWorkerpoolorder(workerpoolorder)
-          .then((o) => iexec.order.publishWorkerpoolorder(o));
-      }
-      for (let i = 0; i < 2; i += 1) {
+          .then((o) =>
+            iexec.order.publishWorkerpoolorder(o, { preflightCheck: false }),
+          );
+
+        // first: request order for app without restrictions
         await iexec.order
-          .signWorkerpoolorder({
-            ...workerpoolorder,
-            apprestrict: getRandomAddress(),
+          .createRequestorder({
+            requester: requesterAddress,
+            app: appAddress,
+            appmaxprice: apporder.appprice,
+            dataset: NULL_ADDRESS,
+            datasetmaxprice: 0,
+            workerpool: NULL_ADDRESS,
+            workerpoolmaxprice: 0,
+            category: 1,
+            trust: 0,
+            volume: 1,
           })
-          .then((o) => iexec.order.publishWorkerpoolorder(o));
-      }
-      for (let i = 0; i < 3; i += 1) {
-        await iexec.order
-          .signWorkerpoolorder({
-            ...workerpoolorder,
-            datasetrestrict: getRandomAddress(),
-          })
-          .then((o) => iexec.order.publishWorkerpoolorder(o));
-      }
-      for (let i = 0; i < 4; i += 1) {
-        await iexec.order
-          .signWorkerpoolorder({
-            ...workerpoolorder,
-            requesterrestrict: getRandomAddress(),
-          })
-          .then((o) => iexec.order.publishWorkerpoolorder(o));
-      }
-      const res1 = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-        workerpool: workerpoolorder.workerpool,
-      });
-      expect(res1.count).toBe(24);
-      expect(res1.orders.length).toBe(20);
-      expect(res1.more).toBeDefined();
-      const res2 = await res1.more();
-      expect(res2.count).toBe(24);
-      expect(res2.orders.length).toBe(4);
-      expect(res2.more).toBeUndefined();
-      const res3 = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-        workerpool: workerpoolorder.workerpool,
-        app: 'any',
-      });
-      expect(res3.count).toBe(26);
-      const res4 = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-        workerpool: workerpoolorder.workerpool,
-        dataset: 'any',
-      });
-      expect(res4.count).toBe(27);
-      const res5 = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-        workerpool: workerpoolorder.workerpool,
-        requester: 'any',
-      });
-      expect(res5.count).toBe(28);
-      const res6 = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-        workerpool: workerpoolorder.workerpool,
-        app: 'any',
-        dataset: 'any',
-        requester: 'any',
-      });
-      expect(res6.count).toBe(33);
-      const res7 = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-        app: 'any',
-        dataset: 'any',
-        requester: 'any',
-      });
-      const res8 = await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-        workerpool: 'any',
-        app: 'any',
-        dataset: 'any',
-        requester: 'any',
-      });
-      expect(res7.count).toBe(res8.count);
-    });
-
-    test('strict option allow filtering only orders for specified app, dataset or requester', async () => {
-      const { iexec } = getTestConfig(iexecTestChain)();
-      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
-        readOnly: true,
-      });
-      // 1 and 2: orders without any restrictions
-      const emptyWorkerpoolOrder = await deployAndGetWorkerpoolorder(iexec);
-      const workerpoolAddress = emptyWorkerpoolOrder.workerpool;
-      await iexec.order
-        .signWorkerpoolorder(emptyWorkerpoolOrder)
-        .then((o) => iexec.order.publishWorkerpoolorder(o));
-      await iexec.order
-        .signWorkerpoolorder(emptyWorkerpoolOrder)
-        .then((o) => iexec.order.publishWorkerpoolorder(o));
-
-      // 3: app restricted order
-      const appAddress = getRandomAddress();
-      emptyWorkerpoolOrder.apprestrict = appAddress;
-      await iexec.order
-        .signWorkerpoolorder(emptyWorkerpoolOrder)
-        .then((o) => iexec.order.publishWorkerpoolorder(o));
-      // reset to empty
-      emptyWorkerpoolOrder.apprestrict = NULL_ADDRESS;
-
-      // 4: dataset restricted order
-      const datasetAddress = getRandomAddress();
-      emptyWorkerpoolOrder.datasetrestrict = datasetAddress;
-      await iexec.order
-        .signWorkerpoolorder(emptyWorkerpoolOrder)
-        .then((o) => iexec.order.publishWorkerpoolorder(o));
-      // reset to empty
-      emptyWorkerpoolOrder.datasetrestrict = NULL_ADDRESS;
-
-      // 5: requester restricted order
-      const requesterAddress = getRandomAddress();
-      emptyWorkerpoolOrder.requesterrestrict = requesterAddress;
-      await iexec.order
-        .signWorkerpoolorder(emptyWorkerpoolOrder)
-        .then((o) => iexec.order.publishWorkerpoolorder(o));
-      // reset to empty
-      emptyWorkerpoolOrder.requesterrestrict = NULL_ADDRESS;
-
-      // all orders (1,2,3,4,5)
-      const allWorkerpoolOrders =
-        await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-          workerpool: workerpoolAddress,
-          app: 'any',
-          requester: 'any',
-          dataset: 'any',
-        });
-
-      expect(allWorkerpoolOrders.count).toBe(5);
-      expect(allWorkerpoolOrders.orders.length).toBe(5);
-
-      // all orders without restrictions (1, 2)
-      const unrestrictedWorkerpoolOrders =
-        await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-          workerpool: workerpoolAddress,
-        });
-      expect(unrestrictedWorkerpoolOrders.count).toBe(2);
-      expect(unrestrictedWorkerpoolOrders.orders.length).toBe(2);
-      expect(unrestrictedWorkerpoolOrders.orders[0].order.apprestrict).toEqual(
-        NULL_ADDRESS,
-      );
-      expect(
-        unrestrictedWorkerpoolOrders.orders[0].order.datasetrestrict,
-      ).toEqual(NULL_ADDRESS);
-      expect(
-        unrestrictedWorkerpoolOrders.orders[0].order.requesterrestrict,
-      ).toEqual(NULL_ADDRESS);
-      expect(unrestrictedWorkerpoolOrders.orders[1].order.apprestrict).toEqual(
-        NULL_ADDRESS,
-      );
-      expect(
-        unrestrictedWorkerpoolOrders.orders[0].order.datasetrestrict,
-      ).toEqual(NULL_ADDRESS);
-      expect(
-        unrestrictedWorkerpoolOrders.orders[0].order.requesterrestrict,
-      ).toEqual(NULL_ADDRESS);
-
-      // all orders without app restriction(1,2) and with app restriction(3)
-      const appRestrictedAppOrders =
-        await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-          workerpool: workerpoolAddress,
-          app: appAddress,
-        });
-      expect(appRestrictedAppOrders.count).toBe(3);
-      expect(appRestrictedAppOrders.orders.length).toBe(3);
-
-      // all orders with app restriction and strict(3)
-      const appStrictAppOrder =
-        await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-          workerpool: workerpoolAddress,
-          app: appAddress,
-          isAppStrict: true,
-        });
-      expect(appStrictAppOrder.count).toBe(1);
-      expect(appStrictAppOrder.orders.length).toBe(1);
-      expect(appStrictAppOrder.orders[0].order.apprestrict).toEqual(appAddress);
-
-      // all orders without dataset restriction(1,2) and with dataset restriction(4)
-      const datasetRestrictedWorkerpoolOrders =
-        await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-          workerpool: workerpoolAddress,
-          dataset: datasetAddress,
-        });
-      expect(datasetRestrictedWorkerpoolOrders.count).toBe(3);
-      expect(datasetRestrictedWorkerpoolOrders.orders.length).toBe(3);
-
-      // all orders with dataset restriction and strict(4)
-      const datasetStrictAppOrder =
-        await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-          workerpool: workerpoolAddress,
-          dataset: datasetAddress,
-          isDatasetStrict: true,
-        });
-      expect(datasetStrictAppOrder.count).toBe(1);
-      expect(datasetStrictAppOrder.orders.length).toBe(1);
-      expect(datasetStrictAppOrder.orders[0].order.datasetrestrict).toEqual(
-        datasetAddress,
-      );
-
-      // all orders without requester restriction(1,2) and with requester restriction(5)
-      const requesterRestrictedAppOrders =
-        await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-          workerpool: workerpoolAddress,
-          requester: requesterAddress,
-        });
-      expect(requesterRestrictedAppOrders.count).toBe(3);
-      expect(requesterRestrictedAppOrders.orders.length).toBe(3);
-
-      // all orders with requester restriction and strict(5)
-      const requesterStrictAppOrders =
-        await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-          workerpool: workerpoolAddress,
-          requester: requesterAddress,
-          isRequesterStrict: true,
-        });
-      expect(requesterStrictAppOrders.count).toBe(1);
-      expect(requesterStrictAppOrders.orders.length).toBe(1);
-      expect(
-        requesterStrictAppOrders.orders[0].order.requesterrestrict,
-      ).toEqual(requesterAddress);
-
-      // all orders with requester, dataset, workerpool restriction and not strict (1,2,3,4,5)
-      const unstrictAppOrders =
-        await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-          workerpool: workerpoolAddress,
-          app: appAddress,
-          isAppStrict: false,
-          requester: requesterAddress,
-          isRequesterStrict: false,
-          dataset: datasetAddress,
-          isDatasetStrict: false,
-        });
-      expect(unstrictAppOrders.count).toBe(5);
-      expect(unstrictAppOrders.orders.length).toBe(5);
-
-      // all orders with requester, dataset, workerpool restriction and strict
-      const strictAppOrders =
-        await iexecReadOnly.orderbook.fetchWorkerpoolOrderbook({
-          workerpool: workerpoolAddress,
-          app: appAddress,
-          isAppStrict: true,
-          requester: requesterAddress,
-          isRequesterStrict: true,
-          dataset: datasetAddress,
-          isDatasetStrict: true,
-        });
-      expect(strictAppOrders.count).toBe(0);
-      expect(strictAppOrders.orders.length).toBe(0);
-    });
-  });
-
-  describe('fetchRequestOrderbook()', () => {
-    test('returns orders available fo anyone', async () => {
-      const { iexec, wallet } = getTestConfig(iexecTestChain)();
-      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
-        readOnly: true,
-      });
-      const apporder = await deployAndGetApporder(iexec);
-      const workerpoolorder = await deployAndGetWorkerpoolorder(iexec, {
-        category: 2,
-      });
-      const requestorder = await getMatchableRequestorder(iexec, {
-        apporder,
-        workerpoolorder,
-      });
-      await iexec.order.publishApporder(apporder);
-      await iexec.order.publishWorkerpoolorder(workerpoolorder);
-      for (let i = 0; i < 25; i += 1) {
-        await iexec.order
-          .signRequestorder(
-            { ...requestorder, workerpool: NULL_ADDRESS },
-            { preflightCheck: false },
+          .then((o) =>
+            iexec.order.signRequestorder(o, { preflightCheck: false }),
           )
           .then((o) =>
-            iexec.order.publishRequestorder(o, {
-              preflightCheck: false,
-            }),
+            iexec.order.publishRequestorder(o, { preflightCheck: false }),
           );
-      }
-      for (let i = 0; i < 2; i += 1) {
+
+        // second: request order for app with workerpool and dataset restrictions
         await iexec.order
-          .signRequestorder(
-            { ...requestorder, workerpool: getRandomAddress() },
-            { preflightCheck: false },
+          .createRequestorder({
+            requester: requesterAddress,
+            app: appAddress,
+            appmaxprice: apporder.appprice,
+            dataset: datasetAddress,
+            datasetmaxprice: 0,
+            workerpool: workerpoolAddress,
+            workerpoolmaxprice: 0,
+            category: 1,
+            trust: 0,
+            volume: 1,
+          })
+          .then((o) =>
+            iexec.order.signRequestorder(o, { preflightCheck: false }),
           )
           .then((o) =>
-            iexec.order.publishRequestorder(o, {
-              preflightCheck: false,
-            }),
+            iexec.order.publishRequestorder(o, { preflightCheck: false }),
           );
-      }
-      const res1 = await iexecReadOnly.orderbook.fetchRequestOrderbook({
-        requester: wallet.address,
-        category: 2,
-      });
-      expect(res1.count).toBe(25);
-      expect(res1.orders.length).toBe(20);
-      expect(res1.more).toBeDefined();
-      const res2 = await res1.more();
-      expect(res2.count).toBe(25);
-      expect(res2.orders.length >= 5).toBe(true);
-      if (res2.orders.length < 20) {
-        expect(res2.more).toBeUndefined();
-      }
-      const res3 = await iexecReadOnly.orderbook.fetchRequestOrderbook({
-        requester: wallet.address,
-        category: 2,
-        workerpool: 'any',
-      });
-      expect(res3.count).toBe(27);
-      const res4 = await iexecReadOnly.orderbook.fetchRequestOrderbook({
-        workerpool: 'any',
-      });
-      const res5 = await iexecReadOnly.orderbook.fetchRequestOrderbook({
-        requester: 'any',
-        workerpool: 'any',
-      });
-      expect(res4.count).toBe(res5.count);
-    });
 
-    test('strict option allow filtering only orders for specified workerpool', async () => {
-      const { iexec, wallet } = getTestConfig(iexecTestChain)();
-      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
-        readOnly: true,
-      });
-      const requesterAddress = wallet.address;
+        // request orders restricted by app - always strict (1,2)
+        const appRestrictedRequestOrders =
+          await iexecReadOnly.orderbook.fetchRequestOrderbook({
+            requester: requesterAddress,
+            workerpool: 'any',
+            app: appAddress,
+          });
+        expect(appRestrictedRequestOrders.count).toBe(2);
+        expect(appRestrictedRequestOrders.orders.length).toBe(2);
 
-      const apporder = await deployAndGetApporder(iexec);
-      const appAddress = apporder.app;
-      await iexec.order
-        .signApporder(apporder)
-        .then((o) => iexec.order.publishApporder(o));
+        // request orders restricted by dataset - always strict (2)
+        const datasetRestrictedRequestOrders =
+          await iexecReadOnly.orderbook.fetchRequestOrderbook({
+            requester: requesterAddress,
+            dataset: datasetAddress,
+            workerpool: 'any',
+          });
+        expect(datasetRestrictedRequestOrders.count).toBe(1);
+        expect(datasetRestrictedRequestOrders.orders.length).toBe(1);
 
-      const datasetorder = await deployAndGetDatasetorder(iexec);
-      const datasetAddress = datasetorder.dataset;
-      await iexec.order
-        .signDatasetorder(datasetorder)
-        .then((o) =>
-          iexec.order.publishDatasetorder(o, { preflightCheck: false }),
+        // request orders restricted by workerpool (2)
+        const workerpoolRestrictedRequestOrders =
+          await iexecReadOnly.orderbook.fetchRequestOrderbook({
+            requester: requesterAddress,
+            workerpool: workerpoolAddress,
+            app: appAddress,
+          });
+        expect(workerpoolRestrictedRequestOrders.count).toBe(2);
+        expect(workerpoolRestrictedRequestOrders.orders.length).toBe(2);
+
+        // request orders restricted by workerpool and strict (1)
+        const workerpoolSrictRequestOrders =
+          await iexecReadOnly.orderbook.fetchRequestOrderbook({
+            requester: requesterAddress,
+            workerpool: workerpoolAddress,
+            isWorkerpoolStrict: true,
+            app: appAddress,
+          });
+        expect(workerpoolSrictRequestOrders.count).toBe(1);
+        expect(workerpoolSrictRequestOrders.orders.length).toBe(1);
+        expect(workerpoolSrictRequestOrders.orders[0].order.workerpool).toEqual(
+          workerpoolAddress,
         );
-
-      const workerpoolorder = await deployAndGetWorkerpoolorder(iexec);
-      const workerpoolAddress = workerpoolorder.workerpool;
-      await iexec.order
-        .signWorkerpoolorder(workerpoolorder)
-        .then((o) =>
-          iexec.order.publishWorkerpoolorder(o, { preflightCheck: false }),
-        );
-
-      // first: request order for app without restrictions
-      await iexec.order
-        .createRequestorder({
-          requester: requesterAddress,
-          app: appAddress,
-          appmaxprice: apporder.appprice,
-          dataset: NULL_ADDRESS,
-          datasetmaxprice: 0,
-          workerpool: NULL_ADDRESS,
-          workerpoolmaxprice: 0,
-          category: 1,
-          trust: 0,
-          volume: 1,
-        })
-        .then((o) => iexec.order.signRequestorder(o, { preflightCheck: false }))
-        .then((o) =>
-          iexec.order.publishRequestorder(o, { preflightCheck: false }),
-        );
-
-      // second: request order for app with workerpool and dataset restrictions
-      await iexec.order
-        .createRequestorder({
-          requester: requesterAddress,
-          app: appAddress,
-          appmaxprice: apporder.appprice,
-          dataset: datasetAddress,
-          datasetmaxprice: 0,
-          workerpool: workerpoolAddress,
-          workerpoolmaxprice: 0,
-          category: 1,
-          trust: 0,
-          volume: 1,
-        })
-        .then((o) => iexec.order.signRequestorder(o, { preflightCheck: false }))
-        .then((o) =>
-          iexec.order.publishRequestorder(o, { preflightCheck: false }),
-        );
-
-      // request orders restricted by app - always strict (1,2)
-      const appRestrictedRequestOrders =
-        await iexecReadOnly.orderbook.fetchRequestOrderbook({
-          requester: requesterAddress,
-          workerpool: 'any',
-          app: appAddress,
-        });
-      expect(appRestrictedRequestOrders.count).toBe(2);
-      expect(appRestrictedRequestOrders.orders.length).toBe(2);
-
-      // request orders restricted by dataset - always strict (2)
-      const datasetRestrictedRequestOrders =
-        await iexecReadOnly.orderbook.fetchRequestOrderbook({
-          requester: requesterAddress,
-          dataset: datasetAddress,
-          workerpool: 'any',
-        });
-      expect(datasetRestrictedRequestOrders.count).toBe(1);
-      expect(datasetRestrictedRequestOrders.orders.length).toBe(1);
-
-      // request orders restricted by workerpool (2)
-      const workerpoolRestrictedRequestOrders =
-        await iexecReadOnly.orderbook.fetchRequestOrderbook({
-          requester: requesterAddress,
-          workerpool: workerpoolAddress,
-          app: appAddress,
-        });
-      expect(workerpoolRestrictedRequestOrders.count).toBe(2);
-      expect(workerpoolRestrictedRequestOrders.orders.length).toBe(2);
-
-      // request orders restricted by workerpool and strict (1)
-      const workerpoolSrictRequestOrders =
-        await iexecReadOnly.orderbook.fetchRequestOrderbook({
-          requester: requesterAddress,
-          workerpool: workerpoolAddress,
-          isWorkerpoolStrict: true,
-          app: appAddress,
-        });
-      expect(workerpoolSrictRequestOrders.count).toBe(1);
-      expect(workerpoolSrictRequestOrders.orders.length).toBe(1);
-      expect(workerpoolSrictRequestOrders.orders[0].order.workerpool).toEqual(
-        workerpoolAddress,
-      );
+      });
     });
   });
 });

--- a/test/lib/e2e/IExecTaskModule.test.js
+++ b/test/lib/e2e/IExecTaskModule.test.js
@@ -4,11 +4,14 @@ import { describe, test, expect } from '@jest/globals';
 import {
   deployAndGetApporder,
   deployAndGetWorkerpoolorder,
+  expectAsyncCustomError,
   getMatchableRequestorder,
   getTestConfig,
 } from '../lib-test-utils';
 import {
   NULL_BYTES32,
+  SERVICE_HTTP_500_URL,
+  SERVICE_UNREACHABLE_URL,
   TEST_CHAINS,
   adminCreateCategory,
   initializeTask,
@@ -16,12 +19,60 @@ import {
 } from '../../test-utils';
 import '../../jest-setup';
 import { errors } from '../../../src/lib/index';
+import { IpfsGatewayCallError } from '../../../src/lib/errors';
 
 const { ObjectNotFoundError } = errors;
 
 const iexecTestChain = TEST_CHAINS['bellecour-fork'];
 
 describe('task', () => {
+  describe('fetchResults()', () => {
+    const BELLECOUR_COMPLETED_TASK_ID =
+      '0x71a9ccb619dd7712b1cd6ee88c018ef4da05820d95e3bfd6693f4914cae39181';
+
+    test("throw a IpfsGatewayCallError when the IPFS gateway can't be reached", async () => {
+      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+        readOnly: true,
+        options: {
+          ipfsGatewayURL: SERVICE_UNREACHABLE_URL,
+        },
+      });
+      await expectAsyncCustomError(
+        iexecReadOnly.task.fetchResults(BELLECOUR_COMPLETED_TASK_ID),
+        {
+          constructor: IpfsGatewayCallError,
+          message: `IPFS gateway error: Connection to ${SERVICE_UNREACHABLE_URL} failed with a network error`,
+        },
+      );
+    });
+
+    test('throw a IpfsGatewayCallError when the IPFS gateway encounters an error', async () => {
+      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+        readOnly: true,
+        options: {
+          ipfsGatewayURL: SERVICE_HTTP_500_URL,
+        },
+      });
+      await expectAsyncCustomError(
+        iexecReadOnly.task.fetchResults(BELLECOUR_COMPLETED_TASK_ID),
+        {
+          constructor: IpfsGatewayCallError,
+          message: `IPFS gateway error: Server at ${SERVICE_HTTP_500_URL} encountered an internal error`,
+        },
+      );
+    });
+
+    test('downloads the result archive from IPFS', async () => {
+      const { iexec: iexecReadOnly } = getTestConfig(iexecTestChain)({
+        readOnly: true,
+      });
+      const res = await iexecReadOnly.task.fetchResults(
+        BELLECOUR_COMPLETED_TASK_ID,
+      );
+      expect(res).toBeInstanceOf(Response);
+    });
+  });
+
   describe.skip('obsTask()', () => {
     test('emits task updates', async () => {
       const { iexec } = getTestConfig(iexecTestChain)();

--- a/test/lib/e2e/utils.test.js
+++ b/test/lib/e2e/utils.test.js
@@ -387,7 +387,7 @@ describe('utils', () => {
       expect(tx0).toBeTxHash();
 
       await expect(iexec.ens.claimName(`name-${getId()}`)).rejects.toThrow(
-        Error('nonce too low'),
+        'nonce too low',
       );
 
       nonceProvider.increaseNonce();
@@ -398,7 +398,7 @@ describe('utils', () => {
       expect(tx1).toBeTxHash();
 
       await expect(iexec.ens.claimName(`name-${getId()}`)).rejects.toThrow(
-        Error('nonce too low'),
+        'nonce too low',
       );
 
       nonceProvider.increaseNonce();

--- a/test/lib/lib-test-utils.js
+++ b/test/lib/lib-test-utils.js
@@ -1,3 +1,6 @@
+// @jest/global comes with jest
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { expect } from '@jest/globals';
 import { Wallet } from 'ethers';
 import {
   NULL_ADDRESS,
@@ -242,4 +245,21 @@ export const runObservableSubscribe = (observable) => {
     unsubscribe,
     wait,
   };
+};
+
+export const expectAsyncCustomError = async (
+  executor,
+  { constructor, message },
+) => {
+  const didNotThrowError = Error('Did not throw');
+  try {
+    await executor;
+    throw didNotThrowError;
+  } catch (e) {
+    if (e === didNotThrowError) {
+      throw e;
+    }
+    expect(e).toBeInstanceOf(constructor);
+    expect(e.message).toBe(message);
+  }
 };

--- a/test/mock/server/http500.nginx.conf
+++ b/test/mock/server/http500.nginx.conf
@@ -1,0 +1,5 @@
+server {
+    listen       80;
+    server_name  localhost;
+    return 500 "internal error";
+}

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,6 +1,13 @@
 import { randomInt } from 'crypto';
 import { exec } from 'child_process';
-import { Wallet, JsonRpcProvider, ethers, Contract } from 'ethers';
+import {
+  Wallet,
+  JsonRpcProvider,
+  ethers,
+  Contract,
+  hexlify,
+  randomBytes,
+} from 'ethers';
 import { IExec } from '../src/lib';
 import { getSignerFromPrivateKey } from '../src/lib/utils';
 
@@ -36,6 +43,12 @@ export const { INFURA_PROJECT_ID, ETHERSCAN_API_KEY, ALCHEMY_API_KEY } =
 console.log('using env INFURA_PROJECT_ID', !!INFURA_PROJECT_ID);
 console.log('using env ETHERSCAN_API_KEY', !!ETHERSCAN_API_KEY);
 console.log('using env ALCHEMY_API_KEY', !!ALCHEMY_API_KEY);
+
+export const SERVICE_HTTP_500_URL = DRONE
+  ? 'http://server-error-500'
+  : 'http://localhost:5500';
+
+export const SERVICE_UNREACHABLE_URL = 'http://unreachable:80';
 
 export const TEST_CHAINS = {
   // autoseal chain with iExec token
@@ -112,6 +125,7 @@ export const getRandomWallet = () => {
 
 export const getRandomAddress = () => getRandomWallet().address;
 
+export const getRandomBytes32 = () => hexlify(randomBytes(32));
 export class InjectedProvider {
   constructor(rpcUrl, privateKey) {
     this.signer = new Wallet(privateKey, new JsonRpcProvider(rpcUrl));

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -45,7 +45,7 @@ console.log('using env ETHERSCAN_API_KEY', !!ETHERSCAN_API_KEY);
 console.log('using env ALCHEMY_API_KEY', !!ALCHEMY_API_KEY);
 
 export const SERVICE_HTTP_500_URL = DRONE
-  ? 'http://server-error-500'
+  ? 'http://server-error-500:80'
   : 'http://localhost:5500';
 
 export const SERVICE_UNREACHABLE_URL = 'http://unreachable:80';

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -45,7 +45,7 @@ console.log('using env ETHERSCAN_API_KEY', !!ETHERSCAN_API_KEY);
 console.log('using env ALCHEMY_API_KEY', !!ALCHEMY_API_KEY);
 
 export const SERVICE_HTTP_500_URL = DRONE
-  ? 'http://server-error-500:80'
+  ? 'http://service-internal-error:80'
   : 'http://localhost:5500';
 
 export const SERVICE_UNREACHABLE_URL = 'http://unreachable:80';


### PR DESCRIPTION
### Added

- a generic `ApiCallError` is thrown when a network error occurs while connecting to a service or when the service returns a HTTP 5xx status code, each service has a dedicated inherited error class
  - `SmsCallError` for SMS call errors
  - `ResultProxyCallError` for Result Proxy call errors
  - `MarketCallError` for Market API call errors
  - `IpfsGatewayCallError` for IPFS gateway call errors
  - `WorkerpoolCallError` for workerpool API call errors
- Error `cause` is now set in errors everywhere `originalError` was used

### Changed

- [DEPRECATED] `originalError` is deprecated in favor of Error `cause`