### PR TITLE
Voucher is always optional

### DIFF
--- a/docs/classes/IExecConfig.md
+++ b/docs/classes/IExecConfig.md
@@ -242,22 +242,24 @@ ___
 
 ### resolveVoucherHubAddress
 
-▸ **resolveVoucherHubAddress**(): `Promise`<`string`\>
+▸ **resolveVoucherHubAddress**(): `Promise`<``null`` \| `string`\>
 
 resolve the current VoucherHub contract address
+returns `null` if not available
 
 #### Returns
 
-`Promise`<`string`\>
+`Promise`<``null`` \| `string`\>
 
 ___
 
 ### resolveVoucherSubgraphURL
 
-▸ **resolveVoucherSubgraphURL**(): `Promise`<`string`\>
+▸ **resolveVoucherSubgraphURL**(): `Promise`<``null`` \| `string`\>
 
 resolve the current voucher subgraph URL
+returns `null` if not available
 
 #### Returns
 
-`Promise`<`string`\>
+`Promise`<``null`` \| `string`\>

--- a/docs/classes/IExecOrderModule.md
+++ b/docs/classes/IExecOrderModule.md
@@ -356,12 +356,12 @@ console.log(`sponsored cost covered by voucher: ${result.sponsored} nRLC`);
 | Name | Type |
 | :------ | :------ |
 | `orders` | `Object` |
-| `orders.apporder` | `any` |
-| `orders.datasetorder` | `any` |
-| `orders.requestorder` | `any` |
-| `orders.workerpoolorder` | `any` |
+| `orders.apporder` | [`ConsumableApporder`](../interfaces/internal_.ConsumableApporder.md) |
+| `orders.datasetorder?` | [`ConsumableDatasetorder`](../interfaces/internal_.ConsumableDatasetorder.md) |
+| `orders.requestorder` | [`ConsumableRequestorder`](../interfaces/internal_.ConsumableRequestorder.md) |
+| `orders.workerpoolorder` | [`ConsumableWorkerpoolorder`](../interfaces/internal_.ConsumableWorkerpoolorder.md) |
 | `options?` | `Object` |
-| `options.useVoucher` | `any` |
+| `options.useVoucher?` | `boolean` |
 
 #### Returns
 

--- a/src/common/generated/sdk/package.js
+++ b/src/common/generated/sdk/package.js
@@ -1,6 +1,6 @@
 // this file is auto generated do not edit it
 /* eslint-disable */
 export const name = "iexec";
-export const version = "8.8.0";
+export const version = "8.9.0";
 export const description = "iExec SDK";
 export default { name, version, description };

--- a/src/common/utils/graphql-utils.js
+++ b/src/common/utils/graphql-utils.js
@@ -1,9 +1,0 @@
-import { GraphQLClient } from 'graphql-request';
-
-export const getGraphQLClient = (subgraphUrl) => {
-  try {
-    return new GraphQLClient(subgraphUrl);
-  } catch (error) {
-    throw new Error(`Failed to create GraphQLClient: ${error.message}`);
-  }
-};

--- a/src/common/utils/voucher-utils.js
+++ b/src/common/utils/voucher-utils.js
@@ -1,5 +1,7 @@
 import { Contract } from 'ethers';
+import { GraphQLClient } from 'graphql-request';
 import { throwIfMissing } from './validator.js';
+import { ConfigurationError } from './errors.js';
 import { abi as voucherHubAbi } from '../voucher/abi/VoucherHub.js';
 import { abi as voucherAbi } from '../voucher/abi/Voucher.js';
 
@@ -10,5 +12,28 @@ export const getVoucherContract = (
 
 export const getVoucherHubContract = (
   contracts = throwIfMissing(),
-  voucherHubAddress = throwIfMissing(),
-) => new Contract(voucherHubAddress, voucherHubAbi, contracts.provider);
+  voucherHubAddress,
+) => {
+  if (!voucherHubAddress) {
+    throw new ConfigurationError(
+      `voucherHubAddress option not set and no default value for your chain ${contracts.chainId}`,
+    );
+  }
+  return new Contract(voucherHubAddress, voucherHubAbi, contracts.provider);
+};
+
+export const getVoucherSubgraphClient = (
+  contracts = throwIfMissing(),
+  voucherSubgraphUrl,
+) => {
+  if (!voucherSubgraphUrl) {
+    throw new ConfigurationError(
+      `voucherSubgraphURL option not set and no default value for your chain ${contracts.chainId}`,
+    );
+  }
+  try {
+    return new GraphQLClient(voucherSubgraphUrl);
+  } catch (error) {
+    throw Error(`Failed to create GraphQLClient: ${error.message}`);
+  }
+};

--- a/src/common/voucher/voucher.js
+++ b/src/common/voucher/voucher.js
@@ -47,6 +47,10 @@ export const showUserVoucher = async (
       .required()
       .label('owner')
       .validate(owner);
+    const graphQLClient = getVoucherSubgraphClient(
+      contracts,
+      voucherSubgraphURL,
+    );
     const voucherAddress = await fetchVoucherAddress(
       contracts,
       voucherHubAddress,
@@ -67,10 +71,6 @@ export const showUserVoucher = async (
       contracts,
       vOwner,
       voucherAddress,
-    );
-    const graphQLClient = getVoucherSubgraphClient(
-      contracts,
-      voucherSubgraphURL,
     );
     const fetchVoucherInfo = getVoucherInfo(graphQLClient, voucherAddress);
     const [type, balance, expirationTimestamp, allowanceAmount, voucherInfo] =

--- a/src/common/voucher/voucher.js
+++ b/src/common/voucher/voucher.js
@@ -6,8 +6,10 @@ import { bigIntToBn, checkSigner } from '../utils/utils.js';
 import { getAddress } from '../wallet/address.js';
 import { wrapCall, wrapSend } from '../utils/errorWrappers.js';
 import { getVoucherInfo } from './subgraph/voucherInfo.js';
-import { getGraphQLClient } from '../utils/graphql-utils.js';
-import { getVoucherContract } from '../utils/voucher-utils.js';
+import {
+  getVoucherContract,
+  getVoucherSubgraphClient,
+} from '../utils/voucher-utils.js';
 
 const debug = Debug('iexec:voucher:voucher');
 
@@ -34,8 +36,8 @@ export const fetchVoucherContract = async (
 
 export const showUserVoucher = async (
   contracts = throwIfMissing(),
-  voucherSubgraphURL = throwIfMissing(),
-  voucherHubAddress = throwIfMissing(),
+  voucherSubgraphURL,
+  voucherHubAddress,
   owner = throwIfMissing(),
 ) => {
   try {
@@ -66,7 +68,10 @@ export const showUserVoucher = async (
       vOwner,
       voucherAddress,
     );
-    const graphQLClient = getGraphQLClient(voucherSubgraphURL);
+    const graphQLClient = getVoucherSubgraphClient(
+      contracts,
+      voucherSubgraphURL,
+    );
     const fetchVoucherInfo = getVoucherInfo(graphQLClient, voucherAddress);
     const [type, balance, expirationTimestamp, allowanceAmount, voucherInfo] =
       await Promise.all([

--- a/src/lib/IExecConfig.d.ts
+++ b/src/lib/IExecConfig.d.ts
@@ -203,8 +203,9 @@ export default class IExecConfig {
   resolvePocoSubgraphURL(): Promise<string>;
   /**
    * resolve the current voucher subgraph URL
+   * returns `null` if not available
    */
-  resolveVoucherSubgraphURL(): Promise<string>;
+  resolveVoucherSubgraphURL(): Promise<string | null>;
   /**
    * resolve the current bridge contract address
    */
@@ -219,6 +220,7 @@ export default class IExecConfig {
   resolveEnsPublicResolverAddress(): Promise<string>;
   /**
    * resolve the current VoucherHub contract address
+   * returns `null` if not available
    */
-  resolveVoucherHubAddress(): Promise<string>;
+  resolveVoucherHubAddress(): Promise<string | null>;
 }

--- a/src/lib/IExecConfig.js
+++ b/src/lib/IExecConfig.js
@@ -403,15 +403,12 @@ export default class IExecConfig {
     };
 
     this.resolveVoucherSubgraphURL = async () => {
-      const { chainId } = await networkPromise;
       const chainConfDefaults = await chainConfDefaultsPromise;
       const value = voucherSubgraphURL || chainConfDefaults.voucherSubgraph;
       if (value !== undefined) {
         return value;
       }
-      throw new ConfigurationError(
-        `voucherSubgraphURL option not set and no default value for your chain ${chainId}`,
-      );
+      return null;
     };
 
     this.resolveBridgeAddress = async () => {
@@ -447,15 +444,12 @@ export default class IExecConfig {
     };
 
     this.resolveVoucherHubAddress = async () => {
-      const { chainId } = await networkPromise;
       const chainConfDefaults = await chainConfDefaultsPromise;
       const value = voucherHubAddress || chainConfDefaults.voucherHub;
       if (value !== undefined) {
         return value;
       }
-      throw new ConfigurationError(
-        `voucherHubAddress option not set and no default value for your chain ${chainId}`,
-      );
+      return null;
     };
   }
 }

--- a/src/lib/IExecOrderModule.d.ts
+++ b/src/lib/IExecOrderModule.d.ts
@@ -1054,8 +1054,15 @@ export default class IExecOrderModule extends IExecModule {
    * ```
    */
   estimateMatchOrders(
-    orders: { apporder; datasetorder; workerpoolorder; requestorder },
-    options?: { useVoucher },
+    orders: {
+      apporder: ConsumableApporder;
+      datasetorder?: ConsumableDatasetorder;
+      workerpoolorder: ConsumableWorkerpoolorder;
+      requestorder: ConsumableRequestorder;
+    },
+    options?: {
+      useVoucher?: boolean;
+    },
   ): Promise<{ total: NRlcAmount; sponsored: NRlcAmount }>;
   /**
    * Create an IExecOrderModule instance using an IExecConfig instance

--- a/test/lib/e2e/IExecConfig.test.js
+++ b/test/lib/e2e/IExecConfig.test.js
@@ -1086,15 +1086,12 @@ describe('[IExecConfig]', () => {
         'https://custom-subgraph.iex.ec/subgraph/name',
       );
     });
-    test('throw when not configured on custom chain', async () => {
+    test('returns null when not configured on custom chain', async () => {
       const config = new IExecConfig({
         ethProvider: unknownTestChain.rpcURL,
       });
-      const promise = config.resolveVoucherSubgraphURL();
-      await expect(promise).rejects.toThrow(
-        `voucherSubgraphURL option not set and no default value for your chain ${unknownTestChain.chainId}`,
-      );
-      await expect(promise).rejects.toThrow(Error);
+      const res = await config.resolveVoucherSubgraphURL();
+      expect(res).toBe(null);
     });
     test('throw on network error', async () => {
       const config = new IExecConfig({
@@ -1316,17 +1313,12 @@ describe('[IExecConfig]', () => {
       const promise = config.resolveVoucherHubAddress();
       await expect(promise).resolves.toBe(voucherHubAddressOverride);
     });
-    test('throw on unknown chain', async () => {
+    test('returns null on unknown chain', async () => {
       const config = new IExecConfig({
         ethProvider: unknownTestChain.rpcURL,
       });
-      const promise = config.resolveVoucherHubAddress();
-      await expect(promise).rejects.toThrow(
-        Error(
-          `voucherHubAddress option not set and no default value for your chain ${unknownTestChain.chainId}`,
-        ),
-      );
-      await expect(promise).rejects.toThrow(errors.ConfigurationError);
+      const res = await config.resolveVoucherHubAddress();
+      expect(res).toBe(null);
     });
     test('throw on network error', async () => {
       const config = new IExecConfig({

--- a/test/lib/e2e/IExecOrderModule.test.js
+++ b/test/lib/e2e/IExecOrderModule.test.js
@@ -327,6 +327,34 @@ describe('order', () => {
         iexec.order.signApporder({ ...order, tag: ['tee', 'gramine'] }),
       ).resolves.toBeDefined();
     });
+
+    test('preflightCheck fails with invalid tag', async () => {
+      const { iexec } = getTestConfig(iexecTestChain)();
+      const order = await iexec.order.createApporder({
+        app: getRandomAddress(),
+      });
+      await expect(
+        iexec.order.signApporder({ ...order, tag: ['tee'] }),
+      ).rejects.toThrow(
+        Error(
+          "'tee' tag must be used with a tee framework ('scone'|'gramine')",
+        ),
+      );
+      await expect(
+        iexec.order.signApporder({ ...order, tag: ['scone'] }),
+      ).rejects.toThrow(Error("'scone' tag must be used with 'tee' tag"));
+      await expect(
+        iexec.order.signApporder({ ...order, tag: ['gramine'] }),
+      ).rejects.toThrow(Error("'gramine' tag must be used with 'tee' tag"));
+      await expect(
+        iexec.order.signApporder({
+          ...order,
+          tag: ['tee', 'scone', 'gramine'],
+        }),
+      ).rejects.toThrow(
+        Error("tee framework tags are exclusive ('scone'|'gramine')"),
+      );
+    });
   });
 
   describe('estimateMatchOrders()', () => {
@@ -550,32 +578,6 @@ describe('order', () => {
       });
       expect(matchedOrdersCost.sponsored).toEqual(new BN(0));
     });
-  });
-
-  test('preflightCheck fails with invalid tag', async () => {
-    const { iexec } = getTestConfig(iexecTestChain)();
-    const order = await iexec.order.createApporder({
-      app: getRandomAddress(),
-    });
-    await expect(
-      iexec.order.signApporder({ ...order, tag: ['tee'] }),
-    ).rejects.toThrow(
-      Error("'tee' tag must be used with a tee framework ('scone'|'gramine')"),
-    );
-    await expect(
-      iexec.order.signApporder({ ...order, tag: ['scone'] }),
-    ).rejects.toThrow(Error("'scone' tag must be used with 'tee' tag"));
-    await expect(
-      iexec.order.signApporder({ ...order, tag: ['gramine'] }),
-    ).rejects.toThrow(Error("'gramine' tag must be used with 'tee' tag"));
-    await expect(
-      iexec.order.signApporder({
-        ...order,
-        tag: ['tee', 'scone', 'gramine'],
-      }),
-    ).rejects.toThrow(
-      Error("tee framework tags are exclusive ('scone'|'gramine')"),
-    );
   });
 
   describe('signDatasetorder()', () => {

--- a/test/lib/e2e/IExecVoucherModule.test.js
+++ b/test/lib/e2e/IExecVoucherModule.test.js
@@ -59,6 +59,32 @@ describe('voucher', () => {
   });
 
   describe('showUserVoucher()', () => {
+    test('requires voucherHubAddress to be configured', async () => {
+      const owner = getRandomAddress();
+      const { iexec } = getTestConfig(unknownTestChain)({
+        readOnly: true,
+        options: { voucherSubgraphURL: 'http://voucher-subgraph.iex.ec' },
+      });
+      await expect(iexec.voucher.showUserVoucher(owner)).rejects.toThrow(
+        Error(
+          `voucherHubAddress option not set and no default value for your chain ${unknownTestChain.chainId}`,
+        ),
+      );
+    });
+
+    test('requires voucherSubgraphURL to be configured', async () => {
+      const owner = getRandomAddress();
+      const { iexec } = getTestConfig(unknownTestChain)({
+        readOnly: true,
+        options: { voucherHubAddress: getRandomAddress() },
+      });
+      await expect(iexec.voucher.showUserVoucher(owner)).rejects.toThrow(
+        Error(
+          `voucherSubgraphURL option not set and no default value for your chain ${unknownTestChain.chainId}`,
+        ),
+      );
+    });
+
     test('throw error if user has no voucher', async () => {
       const owner = getRandomAddress();
       const { iexec } = getTestConfig(iexecTestChain)({ readOnly: true });
@@ -158,6 +184,17 @@ describe('voucher', () => {
   });
 
   describe('authorizeRequester()', () => {
+    test('requires voucherHubAddress to be configured', async () => {
+      const { iexec } = getTestConfig(unknownTestChain)();
+      await expect(
+        iexec.voucher.authorizeRequester(getRandomAddress()),
+      ).rejects.toThrow(
+        Error(
+          `voucherHubAddress option not set and no default value for your chain ${unknownTestChain.chainId}`,
+        ),
+      );
+    });
+
     test('requires a signer', async () => {
       const requester = getRandomAddress();
       const { iexec } = getTestConfig(iexecTestChain)({ readOnly: true });
@@ -204,6 +241,17 @@ describe('voucher', () => {
   });
 
   describe('revokeRequesterAuthorization()', () => {
+    test('requires voucherHubAddress to be configured', async () => {
+      const { iexec } = getTestConfig(unknownTestChain)();
+      await expect(
+        iexec.voucher.revokeRequesterAuthorization(getRandomAddress()),
+      ).rejects.toThrow(
+        Error(
+          `voucherHubAddress option not set and no default value for your chain ${unknownTestChain.chainId}`,
+        ),
+      );
+    });
+
     test('requires a signer', async () => {
       const requester = getRandomAddress();
       const { iexec } = getTestConfig(iexecTestChain)({ readOnly: true });


### PR DESCRIPTION
## rational

The voucher is an optional feature for sponsoring the payment of a deal on iExec. The lack of voucher configuration should not prevent using the protocol.

## changes

- `resolveVoucherHubAddress()` may resolve to `null` instead of throwing
- `resolveVoucherSubgraphURL()` may resolve to `null` instead of throwing
- internal method `getVoucherHubContract()` throws a `ConfigurationError` when called without voucherHubAddress
- internal method `getVoucherSubgraphClient()` throws a `ConfigurationError` when called without voucherSubgraphURL
- methods using voucher throw ConfigurationError when called without a proper voucher configuration (voucherHubAddress + voucherSubgraphURL)

## misc

- fixed `estimateMatchOrders` typing
- added tests
