### PR TITLE
prevent double network registration

### DIFF
--- a/src/common/utils/config.js
+++ b/src/common/utils/config.js
@@ -99,8 +99,10 @@ export const getChainDefaults = ({ id, flavour }) => ({
 export const isEnterpriseEnabled = (id) => !!enterpriseEnabledMap[id];
 
 // register ethers unknown networks
-const bellecourNetwork = new Network(networkMap[134].name, 134).attachPlugin(
-  new EnsPlugin(ensMap[134].registry, 134),
-);
-Network.register(bellecourNetwork.chainId, () => bellecourNetwork);
-Network.register(bellecourNetwork.name, () => bellecourNetwork);
+if (Network.from(134).name === 'unknown') {
+  const bellecourNetwork = new Network(networkMap[134].name, 134).attachPlugin(
+    new EnsPlugin(ensMap[134].registry, 134),
+  );
+  Network.register(bellecourNetwork.chainId, () => bellecourNetwork);
+  Network.register(bellecourNetwork.name, () => bellecourNetwork);
+}


### PR DESCRIPTION
do not register network 134 if the network is already known by ethers

this prevents this error to occur

```
TypeError: conflicting network for "" (argument="nameOrChainId", value=134, code=INVALID_ARGUMENT, version=6.13.2)
```
