### PR TITLE
Feature/remove developer logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `iexec_result_storage_proxy` default value is no more set in request params
+- removed deprecated request param `iexec_developer_logger`
 
 ## [8.12.0] 2024-10-22
 

--- a/docs/interfaces/internal_.RequestorderParams.md
+++ b/docs/interfaces/internal_.RequestorderParams.md
@@ -9,7 +9,6 @@
 ### Properties
 
 - [iexec\_args](internal_.RequestorderParams.md#iexec_args)
-- [iexec\_developer\_logger](internal_.RequestorderParams.md#iexec_developer_logger)
 - [iexec\_input\_files](internal_.RequestorderParams.md#iexec_input_files)
 - [iexec\_result\_encryption](internal_.RequestorderParams.md#iexec_result_encryption)
 - [iexec\_result\_storage\_provider](internal_.RequestorderParams.md#iexec_result_storage_provider)
@@ -23,18 +22,6 @@
 • `Optional` **iexec\_args**: `string`
 
 arguments to pass to the app
-
-___
-
-### iexec\_developer\_logger
-
-• `Optional` **iexec\_developer\_logger**: `boolean`
-
-[deprecated]
-
-enable debug logs
-
-default false
 
 ___
 

--- a/src/common/utils/constant.js
+++ b/src/common/utils/constant.js
@@ -43,7 +43,6 @@ export const IEXEC_REQUEST_PARAMS = {
   IEXEC_RESULT_ENCRYPTION: 'iexec_result_encryption',
   IEXEC_RESULT_STORAGE_PROVIDER: 'iexec_result_storage_provider',
   IEXEC_RESULT_STORAGE_PROXY: 'iexec_result_storage_proxy',
-  IEXEC_DEVELOPER_LOGGER: 'iexec_developer_logger',
 };
 
 export const ANY = 'any';

--- a/src/common/utils/validator.js
+++ b/src/common/utils/validator.js
@@ -338,7 +338,6 @@ export const objParamsSchema = () =>
     ),
     [IEXEC_REQUEST_PARAMS.IEXEC_RESULT_STORAGE_PROXY]:
       basicUrlSchema().notRequired(),
-    [IEXEC_REQUEST_PARAMS.IEXEC_DEVELOPER_LOGGER]: boolean().notRequired(), // deprecated
   })
     .json()
     .noUnknown(true, 'Unknown key "${unknown}" in params');

--- a/src/lib/IExecOrderModule.d.ts
+++ b/src/lib/IExecOrderModule.d.ts
@@ -259,14 +259,6 @@ export interface RequestorderParams {
    * default determined by IExecConfig
    */
   iexec_result_storage_proxy?: string;
-  /**
-   * [deprecated]
-   *
-   * enable debug logs
-   *
-   * default false
-   */
-  iexec_developer_logger?: boolean;
 }
 
 /**

--- a/test/lib/unit/validator.test.js
+++ b/test/lib/unit/validator.test.js
@@ -753,17 +753,6 @@ describe('[objParamsSchema]', () => {
     );
   });
 
-  test('with logger (true)', async () => {
-    await expect(
-      objParamsSchema().validate({
-        iexec_developer_logger: true,
-      }),
-    ).resolves.toEqual({
-      iexec_developer_logger: true,
-      iexec_result_storage_provider: 'ipfs',
-    });
-  });
-
   test('with isCallback in context, do not populate storage', async () => {
     await expect(
       objParamsSchema().validate({}, { context: { isCallback: true } }),
@@ -776,6 +765,7 @@ describe('[objParamsSchema]', () => {
         foo: true,
         iexec_tee_post_compute_fingerprint: 'custom-fingerprint', // removed in in v6
         iexec_tee_post_compute_image: 'custom-image', // removed in in v6
+        iexec_developer_logger: true, // removed in v8
       }),
     ).resolves.toEqual({
       iexec_result_storage_provider: 'ipfs',


### PR DESCRIPTION
remove the already deprecated `iexec_developer_logger` key from requestorder params to save some on-chain storage.
further `iexec_developer_logger` value will be stripped without throwing an error, this is a non-breaking change.