### PR TITLE
Feature/use authorized voucher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Next
+
+- added `voucherAddress` option for using a non-owned voucher contract in `matchOrders`
+
 ## [8.13.1] 2025-02-24
 
 ### Changed

--- a/CLI.md
+++ b/CLI.md
@@ -1079,6 +1079,7 @@ Options:
 | --params \<json\> | specify the params of the request<br/>\* usage: --params '{"iexec\_args":"do stuff","iexec\_input\_files":\["https://example.com/file.zip"\]}' |
 | --skip-preflight-check | skip preflight check, this may result in task execution fail |
 | --use-voucher | use the voucher to cover the costs of matching orders |
+| --voucher-address \<voucherAddress\> | specify the voucher contract to use other than the owned voucher |
 
 #### iexec app request-execution
 
@@ -1794,6 +1795,7 @@ Options:
 | --params \<json\> | specify the params of the request, existing request order will be ignored<br/>\* usage: --params '{"iexec\_args":"do stuff","iexec\_input\_files":\["https://example.com/file.zip"\]}' |
 | --skip-preflight-check | skip preflight check, this may result in task execution fail |
 | --use-voucher | use the voucher to cover the costs of matching orders |
+| --voucher-address \<voucherAddress\> | specify the voucher contract to use other than the owned voucher |
 
 #### iexec order publish
 

--- a/docs/classes/IExecOrderModule.md
+++ b/docs/classes/IExecOrderModule.md
@@ -334,7 +334,7 @@ ___
 
 ### estimateMatchOrders
 
-▸ **estimateMatchOrders**(`orders`, `options?`): `Promise`<{ `sponsored`: `NRlcAmount` ; `total`: `NRlcAmount`  }\>
+▸ **estimateMatchOrders**(`orders`, `options?`): `Promise`<{ `sponsored`: [`BN`](utils.BN.md) ; `total`: [`BN`](utils.BN.md)  }\>
 
 estimates the cost of matching the provided orders
 
@@ -362,11 +362,11 @@ console.log(`sponsored cost covered by voucher: ${result.sponsored} nRLC`);
 | `orders.workerpoolorder` | [`ConsumableWorkerpoolorder`](../interfaces/internal_.ConsumableWorkerpoolorder.md) | - |
 | `options?` | `Object` | - |
 | `options.useVoucher?` | `boolean` | use a voucher contract to sponsor the deal |
-| `options.voucherAddress?` | `string` | override the voucher contract to use, must be combined with `useVoucher: true` the user must be authorized to use the voucher by the voucher's owner |
+| `options.voucherAddress?` | `string` | override the voucher contract to use, must be combined with `useVoucher: true` the user must be authorized by the voucher's owner to use it |
 
 #### Returns
 
-`Promise`<{ `sponsored`: `NRlcAmount` ; `total`: `NRlcAmount`  }\>
+`Promise`<{ `sponsored`: [`BN`](utils.BN.md) ; `total`: [`BN`](utils.BN.md)  }\>
 
 ___
 
@@ -497,7 +497,7 @@ console.log(`created deal ${dealid} in tx ${txHash}`);
 | `options?` | `Object` | - |
 | `options.preflightCheck?` | `boolean` | - |
 | `options.useVoucher?` | `boolean` | use a voucher contract to sponsor the deal |
-| `options.voucherAddress?` | `string` | override the voucher contract to use, must be combined with `useVoucher: true` the user must be authorized to use the voucher by the voucher's owner |
+| `options.voucherAddress?` | `string` | override the voucher contract to use, must be combined with `useVoucher: true` the user must be authorized by the voucher's owner to use it |
 
 #### Returns
 

--- a/docs/classes/IExecOrderModule.md
+++ b/docs/classes/IExecOrderModule.md
@@ -353,15 +353,16 @@ console.log(`sponsored cost covered by voucher: ${result.sponsored} nRLC`);
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `orders` | `Object` |
-| `orders.apporder` | [`ConsumableApporder`](../interfaces/internal_.ConsumableApporder.md) |
-| `orders.datasetorder?` | [`ConsumableDatasetorder`](../interfaces/internal_.ConsumableDatasetorder.md) |
-| `orders.requestorder` | [`ConsumableRequestorder`](../interfaces/internal_.ConsumableRequestorder.md) |
-| `orders.workerpoolorder` | [`ConsumableWorkerpoolorder`](../interfaces/internal_.ConsumableWorkerpoolorder.md) |
-| `options?` | `Object` |
-| `options.useVoucher?` | `boolean` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `orders` | `Object` | - |
+| `orders.apporder` | [`ConsumableApporder`](../interfaces/internal_.ConsumableApporder.md) | - |
+| `orders.datasetorder?` | [`ConsumableDatasetorder`](../interfaces/internal_.ConsumableDatasetorder.md) | - |
+| `orders.requestorder` | [`ConsumableRequestorder`](../interfaces/internal_.ConsumableRequestorder.md) | - |
+| `orders.workerpoolorder` | [`ConsumableWorkerpoolorder`](../interfaces/internal_.ConsumableWorkerpoolorder.md) | - |
+| `options?` | `Object` | - |
+| `options.useVoucher?` | `boolean` | use a voucher contract to sponsor the deal |
+| `options.voucherAddress?` | `string` | override the voucher contract to use, must be combined with `useVoucher: true` the user must be authorized to use the voucher by the voucher's owner |
 
 #### Returns
 
@@ -486,16 +487,17 @@ console.log(`created deal ${dealid} in tx ${txHash}`);
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `orders` | `Object` |
-| `orders.apporder` | [`ConsumableApporder`](../interfaces/internal_.ConsumableApporder.md) |
-| `orders.datasetorder?` | [`ConsumableDatasetorder`](../interfaces/internal_.ConsumableDatasetorder.md) |
-| `orders.requestorder` | [`ConsumableRequestorder`](../interfaces/internal_.ConsumableRequestorder.md) |
-| `orders.workerpoolorder` | [`ConsumableWorkerpoolorder`](../interfaces/internal_.ConsumableWorkerpoolorder.md) |
-| `options?` | `Object` |
-| `options.preflightCheck?` | `boolean` |
-| `options.useVoucher?` | `boolean` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `orders` | `Object` | - |
+| `orders.apporder` | [`ConsumableApporder`](../interfaces/internal_.ConsumableApporder.md) | - |
+| `orders.datasetorder?` | [`ConsumableDatasetorder`](../interfaces/internal_.ConsumableDatasetorder.md) | - |
+| `orders.requestorder` | [`ConsumableRequestorder`](../interfaces/internal_.ConsumableRequestorder.md) | - |
+| `orders.workerpoolorder` | [`ConsumableWorkerpoolorder`](../interfaces/internal_.ConsumableWorkerpoolorder.md) | - |
+| `options?` | `Object` | - |
+| `options.preflightCheck?` | `boolean` | - |
+| `options.useVoucher?` | `boolean` | use a voucher contract to sponsor the deal |
+| `options.voucherAddress?` | `string` | override the voucher contract to use, must be combined with `useVoucher: true` the user must be authorized to use the voucher by the voucher's owner |
 
 #### Returns
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -164,7 +164,7 @@ ___
 
 Ƭ **HumanSingleTag**: `string`
 
-human redable task tag
+human readable task tag
 
 example:
 ```js

--- a/src/cli/cmd/iexec-app.js
+++ b/src/cli/cmd/iexec-app.js
@@ -1039,15 +1039,16 @@ run
 
       debug('requestorder', requestorder);
 
-      const { total: totalCost, sponsored } = await estimateMatchOrders(
-        chain.contracts,
-        chain.voucherHub,
+      const { total: totalCost, sponsored } = await estimateMatchOrders({
+        contracts: chain.contracts,
+        voucherHubAddress: chain.voucherHub,
         apporder,
         datasetorder,
         workerpoolorder,
         requestorder,
-        opts.useVoucher,
-      );
+        useVoucher: opts.useVoucher,
+        voucherAddress: opts.voucherAddress,
+      });
 
       spinner.stop();
 
@@ -1087,15 +1088,15 @@ run
       }
 
       spinner.start('Submitting deal');
-      const { dealid, volume, txHash } = await matchOrders(
-        chain.contracts,
-        chain.voucherHub,
+      const { dealid, volume, txHash } = await matchOrders({
+        contracts: chain.contracts,
+        voucherHubAddress: chain.voucherHub,
         apporder,
         datasetorder,
         workerpoolorder,
         requestorder,
-        opts.useVoucher,
-      );
+        useVoucher: opts.useVoucher,
+      });
 
       result.deals.push({ dealid, volume: volume.toString(), txHash });
 

--- a/src/cli/cmd/iexec-app.js
+++ b/src/cli/cmd/iexec-app.js
@@ -586,6 +586,7 @@ run
   .option(...orderOption.params())
   .option(...option.skipPreflightCheck())
   .option(...option.useVoucher())
+  .option(...option.voucherAddress())
   .description(desc.appRun())
   .action(async (appAddress, opts) => {
     await checkUpdate(opts);
@@ -732,14 +733,11 @@ run
       debug('trust', trust);
       const callback = await addressSchema({
         ethProvider: chain.contracts.provider,
-      }).validate(opts.callback || NULL_ADDRESS);
+      }).validate(opts.callback);
       debug('callback', callback);
-      const beneficiary =
-        opts.beneficiary === undefined
-          ? undefined
-          : await addressSchema({
-              ethProvider: chain.contracts.provider,
-            }).validate(opts.beneficiary);
+      const beneficiary = await addressSchema({
+        ethProvider: chain.contracts.provider,
+      }).validate(opts.beneficiary);
       debug('beneficiary', beneficiary);
 
       const watch = !!opts.watch || !!opts.download;
@@ -1096,6 +1094,7 @@ run
         workerpoolorder,
         requestorder,
         useVoucher: opts.useVoucher,
+        voucherAddress: opts.voucherAddress,
       });
 
       result.deals.push({ dealid, volume: volume.toString(), txHash });
@@ -1287,14 +1286,11 @@ requestRun
       debug('trust', trust);
       const callback = await addressSchema({
         ethProvider: chain.contracts.provider,
-      }).validate(opts.callback || NULL_ADDRESS);
+      }).validate(opts.callback);
       debug('callback', callback);
-      const beneficiary =
-        opts.beneficiary === undefined
-          ? undefined
-          : await addressSchema({
-              ethProvider: chain.contracts.provider,
-            }).validate(opts.beneficiary);
+      const beneficiary = await addressSchema({
+        ethProvider: chain.contracts.provider,
+      }).validate(opts.beneficiary);
       debug('beneficiary', beneficiary);
 
       spinner.info('Creating requestorder');

--- a/src/cli/cmd/iexec-order.js
+++ b/src/cli/cmd/iexec-order.js
@@ -452,13 +452,13 @@ fill
         }
         throw Error(`Invalid ${orderName} hash`);
       };
-      const appOrder = opts.app
+      const apporder = opts.app
         ? await getOrderByHash(APP_ORDER, opts.app)
         : signedOrders[chain.id].apporder;
-      const datasetOrder = opts.dataset
+      const datasetorder = opts.dataset
         ? await getOrderByHash(DATASET_ORDER, opts.dataset)
         : signedOrders[chain.id].datasetorder;
-      const workerpoolOrder = opts.workerpool
+      const workerpoolorder = opts.workerpool
         ? await getOrderByHash(WORKERPOOL_ORDER, opts.workerpool)
         : signedOrders[chain.id].workerpoolorder;
       let requestOrderInput;
@@ -472,12 +472,12 @@ fill
 
       const useDataset = requestOrderInput
         ? requestOrderInput.dataset !== NULL_ADDRESS
-        : !!datasetOrder;
+        : !!datasetorder;
       debug('useDataset', useDataset);
 
-      if (!appOrder) throw new Error('Missing apporder');
-      if (!datasetOrder && useDataset) throw new Error('Missing datasetorder');
-      if (!workerpoolOrder) throw new Error('Missing workerpoolorder');
+      if (!apporder) throw new Error('Missing apporder');
+      if (!datasetorder && useDataset) throw new Error('Missing datasetorder');
+      if (!workerpoolorder) throw new Error('Missing workerpoolorder');
 
       const computeRequestOrder = async () => {
         await connectKeystore(chain, keystore, { txOptions });
@@ -486,13 +486,13 @@ fill
             contracts: chain.contracts,
           },
           {
-            app: appOrder.app,
-            appmaxprice: appOrder.appprice || undefined,
-            dataset: useDataset ? datasetOrder.dataset : undefined,
-            datasetmaxprice: useDataset ? datasetOrder.datasetprice : undefined,
-            workerpool: workerpoolOrder.workerpool || undefined,
-            workerpoolmaxprice: workerpoolOrder.workerpoolprice || undefined,
-            category: workerpoolOrder.category,
+            app: apporder.app,
+            appmaxprice: apporder.appprice || undefined,
+            dataset: useDataset ? datasetorder.dataset : undefined,
+            datasetmaxprice: useDataset ? datasetorder.datasetprice : undefined,
+            workerpool: workerpoolorder.workerpool || undefined,
+            workerpoolmaxprice: workerpoolorder.workerpoolprice || undefined,
+            category: workerpoolorder.category,
             params: inputParams || undefined,
           },
         );
@@ -502,8 +502,8 @@ fill
         return signRequestorder(chain.contracts, unsignedOrder);
       };
 
-      const requestOrder = requestOrderInput || (await computeRequestOrder());
-      if (!requestOrder) {
+      const requestorder = requestOrderInput || (await computeRequestOrder());
+      if (!requestorder) {
         throw new Error('Missing requestorder');
       }
 
@@ -512,15 +512,15 @@ fill
           (
             await requestorderSchema()
               .label('requestorder')
-              .validate(requestOrder)
+              .validate(requestorder)
           ).tag,
-          (await apporderSchema().label('apporder').validate(appOrder)).tag,
+          (await apporderSchema().label('apporder').validate(apporder)).tag,
           ...(useDataset
             ? [
                 (
                   await datasetorderSchema()
                     .label('datasetorder')
-                    .validate(datasetOrder)
+                    .validate(datasetorder)
                 ).tag,
               ]
             : []),
@@ -529,7 +529,7 @@ fill
           {
             contracts: chain.contracts,
           },
-          appOrder,
+          apporder,
           { tagOverride: resolvedTag },
         ).catch((e) => {
           throw Error(
@@ -548,7 +548,7 @@ fill
                 teeFramework: await resolveTeeFrameworkFromTag(resolvedTag),
               }),
             },
-            datasetOrder,
+            datasetorder,
             { tagOverride: resolvedTag },
           ).catch((e) => {
             throw Error(
@@ -567,7 +567,7 @@ fill
               teeFramework: await resolveTeeFrameworkFromTag(resolvedTag),
             }),
           },
-          requestOrder,
+          requestorder,
         ).catch((e) => {
           throw Error(
             `Request requirements check failed: ${
@@ -581,15 +581,15 @@ fill
 
       await connectKeystore(chain, keystore, { txOptions });
       spinner.start(info.filling(objName));
-      const { dealid, volume, txHash } = await matchOrders(
-        chain.contracts,
-        chain.voucherHub,
-        appOrder,
-        useDataset ? datasetOrder : undefined,
-        workerpoolOrder,
-        requestOrder,
-        opts.useVoucher,
-      );
+      const { dealid, volume, txHash } = await matchOrders({
+        contracts: chain.contracts,
+        voucherHubAddress: chain.voucherHub,
+        apporder,
+        datasetorder: useDataset ? datasetorder : undefined,
+        workerpoolorder,
+        requestorder,
+        useVoucher: opts.useVoucher,
+      });
       spinner.succeed(
         `${volume} task successfully purchased with dealid ${dealid}`,
         { raw: { dealid, volume: volume.toString(), txHash } },

--- a/src/cli/cmd/iexec-order.js
+++ b/src/cli/cmd/iexec-order.js
@@ -416,6 +416,7 @@ fill
   .option(...option.fillRequestParams())
   .option(...option.skipPreflightCheck())
   .option(...option.useVoucher())
+  .option(...option.voucherAddress())
   .description(desc.fill(objName))
   .action(async (opts) => {
     await checkUpdate(opts);
@@ -589,6 +590,7 @@ fill
         workerpoolorder,
         requestorder,
         useVoucher: opts.useVoucher,
+        voucherAddress: opts.voucherAddress,
       });
       spinner.succeed(
         `${volume} task successfully purchased with dealid ${dealid}`,

--- a/src/cli/utils/cli-helper.js
+++ b/src/cli/utils/cli-helper.js
@@ -401,6 +401,10 @@ export const option = {
     '--use-voucher',
     'use the voucher to cover the costs of matching orders',
   ],
+  voucherAddress: () => [
+    '--voucher-address <voucherAddress>',
+    'specify the voucher contract to use other than the owned voucher',
+  ],
 };
 
 export const optionCreator = {

--- a/src/cli/utils/fs.js
+++ b/src/cli/utils/fs.js
@@ -88,8 +88,8 @@ const deployedObjSchema = () =>
   object().test(async (obj) => {
     await Promise.all(
       Object.entries({ ...obj }).map(async ([chainId, address]) => {
-        await chainIdSchema().validate(chainId, { strict: true });
-        await addressSchema().validate(address, { strict: true });
+        await chainIdSchema().required().validate(chainId, { strict: true });
+        await addressSchema().required().validate(address, { strict: true });
       }),
     );
     return true;

--- a/src/common/account/allowance.js
+++ b/src/common/account/allowance.js
@@ -12,17 +12,19 @@ const debug = Debug('iexec:account:allowance');
 
 export const approve = async (
   contracts = throwIfMissing(),
-  amount = throwIfMissing(),
-  spenderAddress = throwIfMissing(),
+  amount,
+  spenderAddress,
 ) => {
   try {
     checkSigner(contracts);
-    const vAmount = await nRlcAmountSchema().validate(amount);
+    const vAmount = await nRlcAmountSchema().required().validate(amount);
     if (new BN(vAmount).lten(new BN(0)))
       throw Error('Approve amount must be less than or equals 0');
     const vSpenderAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(spenderAddress);
+    })
+      .required()
+      .validate(spenderAddress);
     const iexecContract = contracts.getIExecContract();
     const tx = await wrapSend(
       iexecContract.approve(vSpenderAddress, vAmount, contracts.txOptions),
@@ -41,16 +43,20 @@ export const approve = async (
 
 export const checkAllowance = async (
   contracts = throwIfMissing(),
-  ownerAddress = throwIfMissing(),
-  spenderAddress = throwIfMissing(),
+  ownerAddress,
+  spenderAddress,
 ) => {
   try {
     const vOwnerAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(ownerAddress);
+    })
+      .required()
+      .validate(ownerAddress);
     const vSpenderAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(spenderAddress);
+    })
+      .required()
+      .validate(spenderAddress);
 
     const iexecContract = contracts.getIExecContract();
     const amount = await wrapCall(

--- a/src/common/account/balance.js
+++ b/src/common/account/balance.js
@@ -5,14 +5,13 @@ import { wrapCall } from '../utils/errorWrappers.js';
 
 const debug = Debug('iexec:account:balance');
 
-export const checkBalance = async (
-  contracts = throwIfMissing(),
-  address = throwIfMissing(),
-) => {
+export const checkBalance = async (contracts = throwIfMissing(), address) => {
   try {
     const vAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(address);
+    })
+      .required()
+      .validate(address);
     const iexecContract = contracts.getIExecContract();
     const { stake, locked } = await wrapCall(
       iexecContract.viewAccount(vAddress),

--- a/src/common/ens/registration.js
+++ b/src/common/ens/registration.js
@@ -31,12 +31,14 @@ const FIFS_DOMAINS = {
 
 export const getDefaultDomain = async (
   contracts = throwIfMissing(),
-  address = throwIfMissing(),
+  address,
 ) => {
   try {
     const vAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(address);
+    })
+      .required()
+      .validate(address);
     const [isApp, isDataset, isWorkerpool] = await Promise.all([
       checkDeployedObj(APP)(contracts, vAddress),
       checkDeployedObj(DATASET)(contracts, vAddress),

--- a/src/common/ens/resolution.js
+++ b/src/common/ens/resolution.js
@@ -45,14 +45,13 @@ export const resolveName = async (
   }
 };
 
-export const lookupAddress = async (
-  contracts = throwIfMissing(),
-  address = throwIfMissing(),
-) => {
+export const lookupAddress = async (contracts = throwIfMissing(), address) => {
   try {
     const vAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(address);
+    })
+      .required()
+      .validate(address);
     await checkEns(contracts);
     return await wrapCall(contracts.provider.lookupAddress(vAddress));
   } catch (e) {

--- a/src/common/execution/deal.js
+++ b/src/common/execution/deal.js
@@ -30,7 +30,7 @@ const debug = Debug('iexec:execution:deal');
 export const fetchRequesterDeals = async (
   contracts = throwIfMissing(),
   iexecGatewayURL = throwIfMissing(),
-  requesterAddress = throwIfMissing(),
+  requesterAddress,
   {
     appAddress,
     datasetAddress,
@@ -42,26 +42,19 @@ export const fetchRequesterDeals = async (
   try {
     const vRequesterAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(requesterAddress);
+    })
+      .required()
+      .validate(requesterAddress);
     const vChainId = await chainIdSchema().validate(contracts.chainId);
-    let vAppAddress;
-    let vDatasetAddress;
-    let vWorkerpoolAddress;
-    if (appAddress) {
-      vAppAddress = await addressSchema({
-        ethProvider: contracts.provider,
-      }).validate(appAddress);
-    }
-    if (datasetAddress) {
-      vDatasetAddress = await addressSchema({
-        ethProvider: contracts.provider,
-      }).validate(datasetAddress);
-    }
-    if (workerpoolAddress) {
-      vWorkerpoolAddress = await addressSchema({
-        ethProvider: contracts.provider,
-      }).validate(workerpoolAddress);
-    }
+    const vAppAddress = await addressSchema({
+      ethProvider: contracts.provider,
+    }).validate(appAddress);
+    const vDatasetAddress = await addressSchema({
+      ethProvider: contracts.provider,
+    }).validate(datasetAddress);
+    const vWorkerpoolAddress = await addressSchema({
+      ethProvider: contracts.provider,
+    }).validate(workerpoolAddress);
     const query = {
       chainId: vChainId,
       requester: vRequesterAddress,

--- a/src/common/execution/debug.js
+++ b/src/common/execution/debug.js
@@ -25,6 +25,7 @@ export const getWorkerpoolApiUrl = async (
     const vAddress = await addressSchema({
       ethProvider: contracts.provider,
     })
+      .required()
       .label('workerpool address')
       .validate(workerpoolAddress);
     const name = await lookupAddress(contracts, vAddress).catch(() => {

--- a/src/common/execution/workerpool.js
+++ b/src/common/execution/workerpool.js
@@ -18,7 +18,9 @@ export const setWorkerpoolApiUrl = async (
   try {
     const vAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(workerpoolAddress);
+    })
+      .required()
+      .validate(workerpoolAddress);
     const vUrl = await workerpoolApiUrlSchema()
       .label('workerpool API url')
       .validate(url);

--- a/src/common/market/marketplace.js
+++ b/src/common/market/marketplace.js
@@ -243,7 +243,7 @@ export const unpublishRequestorder = async (
 export const unpublishAllApporders = async (
   contracts = throwIfMissing(),
   iexecGatewayURL = throwIfMissing(),
-  appAddress = throwIfMissing(),
+  appAddress,
 ) =>
   unpublishOrder(
     contracts,
@@ -254,14 +254,16 @@ export const unpublishAllApporders = async (
       target: UNPUBLISH_TARGET_ALL_ORDERS,
       address: await addressSchema({
         ethProvider: contracts.provider,
-      }).validate(appAddress),
+      })
+        .required()
+        .validate(appAddress),
     },
   );
 
 export const unpublishAllDatasetorders = async (
   contracts = throwIfMissing(),
   iexecGatewayURL = throwIfMissing(),
-  datasetAddress = throwIfMissing(),
+  datasetAddress,
 ) =>
   unpublishOrder(
     contracts,
@@ -272,14 +274,16 @@ export const unpublishAllDatasetorders = async (
       target: UNPUBLISH_TARGET_ALL_ORDERS,
       address: await addressSchema({
         ethProvider: contracts.provider,
-      }).validate(datasetAddress),
+      })
+        .required()
+        .validate(datasetAddress),
     },
   );
 
 export const unpublishAllWorkerpoolorders = async (
   contracts = throwIfMissing(),
   iexecGatewayURL = throwIfMissing(),
-  workerpoolAddress = throwIfMissing(),
+  workerpoolAddress,
 ) =>
   unpublishOrder(
     contracts,
@@ -290,7 +294,9 @@ export const unpublishAllWorkerpoolorders = async (
       target: UNPUBLISH_TARGET_ALL_ORDERS,
       address: await addressSchema({
         ethProvider: contracts.provider,
-      }).validate(workerpoolAddress),
+      })
+        .required()
+        .validate(workerpoolAddress),
     },
   );
 
@@ -312,7 +318,7 @@ export const unpublishAllRequestorders = async (
 export const unpublishLastApporder = async (
   contracts = throwIfMissing(),
   iexecGatewayURL = throwIfMissing(),
-  appAddress = throwIfMissing(),
+  appAddress,
 ) => {
   const unpublished = await unpublishOrder(
     contracts,
@@ -323,7 +329,9 @@ export const unpublishLastApporder = async (
       target: UNPUBLISH_TARGET_LAST_ORDER,
       address: await addressSchema({
         ethProvider: contracts.provider,
-      }).validate(appAddress),
+      })
+        .required()
+        .validate(appAddress),
     },
   );
   return unpublished[0];
@@ -332,7 +340,7 @@ export const unpublishLastApporder = async (
 export const unpublishLastDatasetorder = async (
   contracts = throwIfMissing(),
   iexecGatewayURL = throwIfMissing(),
-  datasetAddress = throwIfMissing(),
+  datasetAddress,
 ) => {
   const unpublished = await unpublishOrder(
     contracts,
@@ -343,7 +351,9 @@ export const unpublishLastDatasetorder = async (
       target: UNPUBLISH_TARGET_LAST_ORDER,
       address: await addressSchema({
         ethProvider: contracts.provider,
-      }).validate(datasetAddress),
+      })
+        .required()
+        .validate(datasetAddress),
     },
   );
   return unpublished[0];
@@ -352,7 +362,7 @@ export const unpublishLastDatasetorder = async (
 export const unpublishLastWorkerpoolorder = async (
   contracts = throwIfMissing(),
   iexecGatewayURL = throwIfMissing(),
-  workerpoolAddress = throwIfMissing(),
+  workerpoolAddress,
 ) => {
   const unpublished = await unpublishOrder(
     contracts,
@@ -363,7 +373,9 @@ export const unpublishLastWorkerpoolorder = async (
       target: UNPUBLISH_TARGET_LAST_ORDER,
       address: await addressSchema({
         ethProvider: contracts.provider,
-      }).validate(workerpoolAddress),
+      })
+        .required()
+        .validate(workerpoolAddress),
     },
   );
   return unpublished[0];

--- a/src/common/market/order.js
+++ b/src/common/market/order.js
@@ -783,21 +783,21 @@ const getMatchableVolume = async (
   }
 };
 
-export const estimateMatchOrders = async (
+export const estimateMatchOrders = async ({
   contracts,
   voucherHubAddress,
-  appOrder,
-  datasetOrder = NULL_DATASETORDER,
-  workerpoolOrder,
-  requestOrder,
+  apporder,
+  datasetorder = NULL_DATASETORDER,
+  workerpoolorder,
+  requestorder,
   useVoucher,
-) => {
+} = {}) => {
   const [vAppOrder, vDatasetOrder, vWorkerpoolOrder, vRequestOrder] =
     await Promise.all([
-      signedApporderSchema().validate(appOrder),
-      signedDatasetorderSchema().validate(datasetOrder),
-      signedWorkerpoolorderSchema().validate(workerpoolOrder),
-      signedRequestorderSchema().validate(requestOrder),
+      signedApporderSchema().validate(apporder),
+      signedDatasetorderSchema().validate(datasetorder),
+      signedWorkerpoolorderSchema().validate(workerpoolorder),
+      signedRequestorderSchema().validate(requestorder),
     ]);
   const matchableVolume = await getMatchableVolume(
     contracts,
@@ -817,7 +817,7 @@ export const estimateMatchOrders = async (
     const voucherAddress = await fetchVoucherAddress(
       contracts,
       voucherHubAddress,
-      requestOrder.requester,
+      requestorder.requester,
     );
     if (!voucherAddress) {
       return { total: totalCost, sponsored: sponsoredCost };
@@ -844,17 +844,15 @@ export const estimateMatchOrders = async (
     ] = await Promise.all([
       voucherHubContract.isAssetEligibleToMatchOrdersSponsoring(
         voucherTypeId,
-        appOrder.app,
+        apporder.app,
       ),
-
       voucherHubContract.isAssetEligibleToMatchOrdersSponsoring(
         voucherTypeId,
-        datasetOrder.dataset,
+        datasetorder.dataset,
       ),
-
       voucherHubContract.isAssetEligibleToMatchOrdersSponsoring(
         voucherTypeId,
-        workerpoolOrder.workerpool,
+        workerpoolorder.workerpool,
       ),
     ]);
 
@@ -873,23 +871,23 @@ export const estimateMatchOrders = async (
   return { total: totalCost, sponsored: sponsoredCost };
 };
 
-export const matchOrders = async (
+export const matchOrders = async ({
   contracts = throwIfMissing(),
   voucherHubAddress,
-  appOrder = throwIfMissing(),
-  datasetOrder = NULL_DATASETORDER,
-  workerpoolOrder = throwIfMissing(),
-  requestOrder = throwIfMissing(),
+  apporder = throwIfMissing(),
+  datasetorder = NULL_DATASETORDER,
+  workerpoolorder = throwIfMissing(),
+  requestorder = throwIfMissing(),
   useVoucher = false,
-) => {
+}) => {
   try {
     checkSigner(contracts);
     const [vAppOrder, vDatasetOrder, vWorkerpoolOrder, vRequestOrder] =
       await Promise.all([
-        signedApporderSchema().validate(appOrder),
-        signedDatasetorderSchema().validate(datasetOrder),
-        signedWorkerpoolorderSchema().validate(workerpoolOrder),
-        signedRequestorderSchema().validate(requestOrder),
+        signedApporderSchema().validate(apporder),
+        signedDatasetorderSchema().validate(datasetorder),
+        signedWorkerpoolorderSchema().validate(workerpoolorder),
+        signedRequestorderSchema().validate(requestorder),
       ]);
 
     // check resulting tag
@@ -937,15 +935,15 @@ export const matchOrders = async (
       const totalCost = costPerTask.mul(matchableVolume);
       const { stake } = await checkBalance(contracts, vRequestOrder.requester);
       if (useVoucher) {
-        const { total, sponsored } = await estimateMatchOrders(
+        const { total, sponsored } = await estimateMatchOrders({
           contracts,
           voucherHubAddress,
-          vAppOrder,
-          vDatasetOrder,
-          vWorkerpoolOrder,
-          vRequestOrder,
+          apporder: vAppOrder,
+          datasetorder: vDatasetOrder,
+          workerpoolorder: vWorkerpoolOrder,
+          requestorder: vRequestOrder,
           useVoucher,
-        );
+        });
         if (total.gt(sponsored)) {
           const allowance = await checkAllowance(
             contracts,

--- a/src/common/market/order.js
+++ b/src/common/market/order.js
@@ -53,6 +53,7 @@ import {
   uint256Schema,
   nRlcAmountSchema,
   throwIfMissing,
+  booleanSchema,
 } from '../utils/validator.js';
 import {
   wrapCall,
@@ -1034,7 +1035,7 @@ export const matchOrders = async ({
 export const createApporder = async (
   contracts = throwIfMissing(),
   {
-    app = throwIfMissing(),
+    app,
     appprice = '0',
     volume = '1',
     tag = NULL_BYTES32,
@@ -1043,7 +1044,10 @@ export const createApporder = async (
     requesterrestrict = NULL_ADDRESS,
   } = {},
 ) => ({
-  app: await addressSchema({ ethProvider: contracts.provider }).validate(app),
+  app: await addressSchema({ ethProvider: contracts.provider })
+    .required()
+    .label('app')
+    .validate(app),
   appprice: await nRlcAmountSchema().validate(appprice),
   volume: await uint256Schema().validate(volume),
   tag: await tagSchema().validate(tag),
@@ -1061,7 +1065,7 @@ export const createApporder = async (
 export const createDatasetorder = async (
   contracts = throwIfMissing(),
   {
-    dataset = throwIfMissing(),
+    dataset,
     datasetprice = '0',
     volume = '1',
     tag = NULL_BYTES32,
@@ -1072,7 +1076,10 @@ export const createDatasetorder = async (
 ) => ({
   dataset: await addressSchema({
     ethProvider: contracts.provider,
-  }).validate(dataset),
+  })
+    .label('dataset')
+    .required()
+    .validate(dataset),
   datasetprice: await nRlcAmountSchema().validate(datasetprice),
   volume: await uint256Schema().validate(volume),
   tag: await tagSchema().validate(tag),
@@ -1123,8 +1130,8 @@ export const createWorkerpoolorder = async (
 export const createRequestorder = async (
   { contracts = throwIfMissing() } = {},
   {
-    app = throwIfMissing(),
-    category = throwIfMissing(),
+    app,
+    category,
     dataset = NULL_ADDRESS,
     workerpool = NULL_ADDRESS,
     appmaxprice = '0',
@@ -1143,7 +1150,10 @@ export const createRequestorder = async (
   return {
     app: await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(app),
+    })
+      .required()
+      .label('app')
+      .validate(app),
     appmaxprice: await nRlcAmountSchema().validate(appmaxprice),
     dataset: await addressSchema({
       ethProvider: contracts.provider,
@@ -1170,7 +1180,10 @@ export const createRequestorder = async (
     callback: await addressSchema({
       ethProvider: contracts.provider,
     }).validate(callback),
-    category: await uint256Schema().validate(category),
+    category: await uint256Schema()
+      .required()
+      .label('category')
+      .validate(category),
     trust: await uint256Schema().validate(trust),
     tag: await tagSchema().validate(tag),
   };

--- a/src/common/protocol/registries.js
+++ b/src/common/protocol/registries.js
@@ -45,31 +45,34 @@ export const checkDeployedObj =
     }
   };
 
-export const checkDeployedApp = async (
-  contracts = throwIfMissing(),
-  address = throwIfMissing(),
-) =>
+export const checkDeployedApp = async (contracts = throwIfMissing(), address) =>
   checkDeployedObj(APP)(
     contracts,
-    await addressSchema({ ethProvider: contracts.provider }).validate(address),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(address),
   );
 
 export const checkDeployedDataset = async (
   contracts = throwIfMissing(),
-  address = throwIfMissing(),
+  address,
 ) =>
   checkDeployedObj(DATASET)(
     contracts,
-    await addressSchema({ ethProvider: contracts.provider }).validate(address),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(address),
   );
 
 export const checkDeployedWorkerpool = async (
   contracts = throwIfMissing(),
-  address = throwIfMissing(),
+  address,
 ) =>
   checkDeployedObj(WORKERPOOL)(
     contracts,
-    await addressSchema({ ethProvider: contracts.provider }).validate(address),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(address),
   );
 
 const toUpperFirst = (str) => ''.concat(str[0].toUpperCase(), str.substr(1));
@@ -183,31 +186,31 @@ const getObjOwner =
     }
   };
 
-export const getAppOwner = async (
-  contracts = throwIfMissing(),
-  address = throwIfMissing(),
-) =>
+export const getAppOwner = async (contracts = throwIfMissing(), address) =>
   getObjOwner(APP)(
     contracts,
-    await addressSchema({ ethProvider: contracts.provider }).validate(address),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(address),
   );
 
-export const getDatasetOwner = async (
-  contracts = throwIfMissing(),
-  address = throwIfMissing(),
-) =>
+export const getDatasetOwner = async (contracts = throwIfMissing(), address) =>
   getObjOwner(DATASET)(
     contracts,
-    await addressSchema({ ethProvider: contracts.provider }).validate(address),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(address),
   );
 
 export const getWorkerpoolOwner = async (
   contracts = throwIfMissing(),
-  address = throwIfMissing(),
+  address,
 ) =>
   getObjOwner(WORKERPOOL)(
     contracts,
-    await addressSchema({ ethProvider: contracts.provider }).validate(address),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(address),
   );
 
 const showObjByAddress =
@@ -216,7 +219,9 @@ const showObjByAddress =
     try {
       const vAddress = await addressSchema({
         ethProvider: contracts.provider,
-      }).validate(objAddress);
+      })
+        .required()
+        .validate(objAddress);
       const isDeployed = await checkDeployedObj(objName)(contracts, objAddress);
       if (!isDeployed)
         throw new ObjectNotFoundError(objName, objAddress, contracts.chainId);
@@ -245,7 +250,9 @@ const countUserObj =
     try {
       const vAddress = await addressSchema({
         ethProvider: contracts.provider,
-      }).validate(userAddress);
+      })
+        .required()
+        .validate(userAddress);
       const registryContract = await wrapCall(
         contracts.fetchRegistryContract(objName),
       );
@@ -259,47 +266,45 @@ const countUserObj =
 
 export const countUserApps = async (
   contracts = throwIfMissing(),
-  userAddress = throwIfMissing(),
+  userAddress,
 ) =>
   countUserObj(APP)(
     contracts,
-    await addressSchema({ ethProvider: contracts.provider }).validate(
-      userAddress,
-    ),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(userAddress),
   );
 export const countUserDatasets = async (
   contracts = throwIfMissing(),
-  userAddress = throwIfMissing(),
+  userAddress,
 ) =>
   countUserObj(DATASET)(
     contracts,
-    await addressSchema({ ethProvider: contracts.provider }).validate(
-      userAddress,
-    ),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(userAddress),
   );
 export const countUserWorkerpools = async (
   contracts = throwIfMissing(),
-  userAddress = throwIfMissing(),
+  userAddress,
 ) =>
   countUserObj(WORKERPOOL)(
     contracts,
-    await addressSchema({ ethProvider: contracts.provider }).validate(
-      userAddress,
-    ),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(userAddress),
   );
 
 const showUserObjByIndex =
   (objName = throwIfMissing()) =>
-  async (
-    contracts = throwIfMissing(),
-    objIndex = throwIfMissing(),
-    userAddress = throwIfMissing(),
-  ) => {
+  async (contracts = throwIfMissing(), objIndex, userAddress) => {
     try {
-      const vIndex = await uint256Schema().validate(objIndex);
+      const vIndex = await uint256Schema().required().validate(objIndex);
       const vAddress = await addressSchema({
         ethProvider: contracts.provider,
-      }).validate(userAddress);
+      })
+        .required()
+        .validate(userAddress);
       const totalObj = await countUserObj(objName)(contracts, userAddress);
       if (new BN(vIndex).gte(totalObj)) throw Error(`${objName} not deployed`);
       const registryContract = await wrapCall(
@@ -336,43 +341,40 @@ const cleanApp = (obj) =>
     },
   );
 
-export const showApp = async (
-  contracts = throwIfMissing(),
-  appAddress = throwIfMissing(),
-) => {
+export const showApp = async (contracts = throwIfMissing(), appAddress) => {
   const { obj, objAddress } = await showObjByAddress(APP)(
     contracts,
-    await addressSchema({ ethProvider: contracts.provider }).validate(
-      appAddress,
-    ),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(appAddress),
   );
   return { objAddress, app: cleanApp(obj) };
 };
 
 export const showUserApp = async (
   contracts = throwIfMissing(),
-  index = throwIfMissing(),
-  userAddress = throwIfMissing(),
+  index,
+  userAddress,
 ) => {
   const { obj, objAddress } = await showUserObjByIndex(APP)(
     contracts,
-    await uint256Schema().validate(index),
-    await addressSchema({ ethProvider: contracts.provider }).validate(
-      userAddress,
-    ),
+    await uint256Schema().required().validate(index),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(userAddress),
   );
   return { objAddress, app: cleanApp(obj) };
 };
 
 export const showDataset = async (
   contracts = throwIfMissing(),
-  datasetAddress = throwIfMissing(),
+  datasetAddress,
 ) => {
   const { obj, objAddress } = await showObjByAddress(DATASET)(
     contracts,
-    await addressSchema({ ethProvider: contracts.provider }).validate(
-      datasetAddress,
-    ),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(datasetAddress),
   );
   const clean = Object.assign(
     cleanObj(obj),
@@ -385,15 +387,15 @@ export const showDataset = async (
 
 export const showUserDataset = async (
   contracts = throwIfMissing(),
-  index = throwIfMissing(),
-  userAddress = throwIfMissing(),
+  index,
+  userAddress,
 ) => {
   const { obj, objAddress } = await showUserObjByIndex(DATASET)(
     contracts,
-    await uint256Schema().validate(index),
-    await addressSchema({ ethProvider: contracts.provider }).validate(
-      userAddress,
-    ),
+    await uint256Schema().required().validate(index),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(userAddress),
   );
   const clean = Object.assign(
     cleanObj(obj),
@@ -406,13 +408,13 @@ export const showUserDataset = async (
 
 export const showWorkerpool = async (
   contracts = throwIfMissing(),
-  workerpoolAddress = throwIfMissing(),
+  workerpoolAddress,
 ) => {
   const { obj, objAddress } = await showObjByAddress(WORKERPOOL)(
     contracts,
-    await addressSchema({ ethProvider: contracts.provider }).validate(
-      workerpoolAddress,
-    ),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(workerpoolAddress),
   );
   const clean = cleanObj(obj);
   return { objAddress, workerpool: clean };
@@ -420,15 +422,15 @@ export const showWorkerpool = async (
 
 export const showUserWorkerpool = async (
   contracts = throwIfMissing(),
-  index = throwIfMissing(),
-  userAddress = throwIfMissing(),
+  index,
+  userAddress,
 ) => {
   const { obj, objAddress } = await showUserObjByIndex(WORKERPOOL)(
     contracts,
-    await uint256Schema().validate(index),
-    await addressSchema({ ethProvider: contracts.provider }).validate(
-      userAddress,
-    ),
+    await uint256Schema().required().validate(index),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(userAddress),
   );
   const clean = cleanObj(obj);
   return { objAddress, workerpool: clean };
@@ -472,37 +474,45 @@ const transferObj =
     }
   };
 
-export const transferApp = async (
-  contracts = throwIfMissing(),
-  address = throwIfMissing(),
-  to = throwIfMissing(),
-) =>
+export const transferApp = async (contracts = throwIfMissing(), address, to) =>
   transferObj(APP)(
     contracts,
-    await addressSchema({ ethProvider: contracts.provider }).validate(address),
-    await addressSchema({ ethProvider: contracts.provider }).validate(to),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(address),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(to),
   );
 
 export const transferDataset = async (
   contracts = throwIfMissing(),
-  address = throwIfMissing(),
-  to = throwIfMissing(),
+  address,
+  to,
 ) =>
   transferObj(DATASET)(
     contracts,
-    await addressSchema({ ethProvider: contracts.provider }).validate(address),
-    await addressSchema({ ethProvider: contracts.provider }).validate(to),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(address),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(to),
   );
 
 export const transferWorkerpool = async (
   contracts = throwIfMissing(),
-  address = throwIfMissing(),
-  to = throwIfMissing(),
+  address,
+  to,
 ) =>
   transferObj(WORKERPOOL)(
     contracts,
-    await addressSchema({ ethProvider: contracts.provider }).validate(address),
-    await addressSchema({ ethProvider: contracts.provider }).validate(to),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(address),
+    await addressSchema({ ethProvider: contracts.provider })
+      .required()
+      .validate(to),
   );
 
 export const resolveTeeFrameworkFromApp = async (

--- a/src/common/sms/check.js
+++ b/src/common/sms/check.js
@@ -24,12 +24,14 @@ const cacheSecretExists = ({ smsURL, kindOfSecret, secretId }) => {
 export const checkWeb3SecretExists = async (
   contracts = throwIfMissing(),
   smsURL = throwIfMissing(),
-  resourceAddress = throwIfMissing(),
+  resourceAddress,
 ) => {
   try {
     const vResourceAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(resourceAddress);
+    })
+      .required()
+      .validate(resourceAddress);
     const kindOfSecret = 'web3';
     const secretId = vResourceAddress;
     const cached = checkCache({ smsURL, kindOfSecret, secretId });
@@ -64,13 +66,15 @@ export const checkWeb3SecretExists = async (
 export const checkWeb2SecretExists = async (
   contracts = throwIfMissing(),
   smsURL = throwIfMissing(),
-  ownerAddress = throwIfMissing(),
-  secretName = throwIfMissing(),
+  ownerAddress,
+  secretName,
 ) => {
   try {
     const vOwnerAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(ownerAddress);
+    })
+      .required()
+      .validate(ownerAddress);
     const kindOfSecret = 'web2';
     const secretId = `${vOwnerAddress}|${secretName}`;
     const cached = checkCache({ smsURL, kindOfSecret, secretId });
@@ -142,12 +146,14 @@ export const checkRequesterSecretExists = async (
 export const checkAppSecretExists = async (
   contracts = throwIfMissing(),
   smsURL = throwIfMissing(),
-  appAddress = throwIfMissing(),
+  appAddress,
 ) => {
   try {
     const vAppAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(appAddress);
+    })
+      .required()
+      .validate(appAddress);
     const kindOfSecret = 'app';
     const secretId = vAppAddress;
     const cached = checkCache({ smsURL, kindOfSecret, secretId });

--- a/src/common/sms/push.js
+++ b/src/common/sms/push.js
@@ -65,14 +65,16 @@ const handleNonUpdatablePushSecret = ({
 export const pushWeb3Secret = async (
   contracts = throwIfMissing(),
   smsURL = throwIfMissing(),
-  resourceAddress = throwIfMissing(),
-  secretValue = throwIfMissing(),
+  resourceAddress,
+  secretValue,
 ) => {
   try {
     checkSigner(contracts);
     const vResourceAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(resourceAddress);
+    })
+      .required()
+      .validate(resourceAddress);
     const vSignerAddress = await getAddress(contracts);
     await stringSchema().validate(secretValue, { strict: true });
     const challenge = getChallengeForSetWeb3Secret(
@@ -222,15 +224,17 @@ export const pushRequesterSecret = async (
 export const pushAppSecret = async (
   contracts = throwIfMissing(),
   smsURL = throwIfMissing(),
-  appAddress = throwIfMissing(),
-  secretValue = throwIfMissing(),
+  appAddress,
+  secretValue,
 ) => {
   try {
     checkSigner(contracts);
     const vSignerAddress = await getAddress(contracts);
     const vAppAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(appAddress);
+    })
+      .required()
+      .validate(appAddress);
     await stringSchema().validate(secretValue, { strict: true });
     const challenge = getChallengeForSetWeb2Secret(
       vAppAddress,

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -111,7 +111,7 @@ export type WeiAmount = number | string | BN;
  */
 export type NRLCAmount = number | string | BN;
 /**
- * human redable task tag
+ * human readable task tag
  *
  * example:
  * ```js

--- a/src/common/utils/validator.js
+++ b/src/common/utils/validator.js
@@ -191,6 +191,9 @@ const testResolveEnsPromise = async (value) => {
 };
 
 const testAddressOrAddressPromise = async (value) => {
+  if (value === undefined) {
+    return true;
+  }
   const resolvedValue = typeof value === 'string' ? value : await value;
   return isAddress(resolvedValue);
 };

--- a/src/common/voucher/voucher.js
+++ b/src/common/voucher/voucher.js
@@ -52,9 +52,7 @@ export const fetchVoucherContract = async (
         ),
       ]);
       if (!userAuthorized && !userIsOwner) {
-        throw new Error(
-          'User is neither the owner of the voucher nor authorized to use the voucher',
-        );
+        throw new Error('User is not authorized to use the voucher');
       }
     } else {
       const ownedVoucherAddress = await fetchVoucherAddress(

--- a/src/common/voucher/voucherHub.js
+++ b/src/common/voucher/voucherHub.js
@@ -14,6 +14,7 @@ export const fetchVoucherAddress = async (
 ) => {
   try {
     const vOwner = await addressSchema({ ethProvider: contracts.provider })
+      .required()
       .label('owner')
       .validate(owner);
     const voucherHubContract = getVoucherHubContract(
@@ -24,6 +25,29 @@ export const fetchVoucherAddress = async (
     return address !== NULL_ADDRESS ? address : null;
   } catch (error) {
     debug('fetchVoucherAddress()', error);
+    throw error;
+  }
+};
+
+export const isVoucherAddress = async (
+  contracts = throwIfMissing(),
+  voucherHubAddress = throwIfMissing(),
+  voucherAddress,
+) => {
+  try {
+    const vVoucherAddress = await addressSchema({
+      ethProvider: contracts.provider,
+    })
+      .required()
+      .label('voucherAddress')
+      .validate(voucherAddress);
+    const voucherHubContract = getVoucherHubContract(
+      contracts,
+      voucherHubAddress,
+    );
+    return wrapCall(voucherHubContract.isVoucher(vVoucherAddress));
+  } catch (error) {
+    debug('checkVoucherAddress()', error);
     throw error;
   }
 };

--- a/src/common/wallet/balance.js
+++ b/src/common/wallet/balance.js
@@ -5,13 +5,12 @@ import { wrapCall } from '../utils/errorWrappers.js';
 
 const debug = Debug('iexec:wallet:balance');
 
-export const getRlcBalance = async (
-  contracts = throwIfMissing(),
-  address = throwIfMissing(),
-) => {
+export const getRlcBalance = async (contracts = throwIfMissing(), address) => {
   const vAddress = await addressSchema({
     ethProvider: contracts.provider,
-  }).validate(address);
+  })
+    .required()
+    .validate(address);
   const { isNative } = contracts;
   if (isNative) {
     const weiBalance = await contracts.provider.getBalance(vAddress);
@@ -22,25 +21,23 @@ export const getRlcBalance = async (
   return bigIntToBn(nRlcBalance);
 };
 
-export const getEthBalance = async (
-  contracts = throwIfMissing(),
-  address = throwIfMissing(),
-) => {
+export const getEthBalance = async (contracts = throwIfMissing(), address) => {
   const vAddress = await addressSchema({
     ethProvider: contracts.provider,
-  }).validate(address);
+  })
+    .required()
+    .validate(address);
   const weiBalance = await contracts.provider.getBalance(vAddress);
   return bigIntToBn(weiBalance);
 };
 
-export const checkBalances = async (
-  contracts = throwIfMissing(),
-  address = throwIfMissing(),
-) => {
+export const checkBalances = async (contracts = throwIfMissing(), address) => {
   try {
     const vAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(address);
+    })
+      .required()
+      .validate(address);
     const [weiBalance, rlcBalance] = await Promise.all([
       getEthBalance(contracts, vAddress),
       getRlcBalance(contracts, vAddress),

--- a/src/common/wallet/bridge.js
+++ b/src/common/wallet/bridge.js
@@ -64,8 +64,8 @@ const findBlockNumberBeforeTimestamp = async (
 
 export const obsBridgeToSidechain = (
   contracts = throwIfMissing(),
-  bridgeAddress = throwIfMissing(),
-  nRlcAmount = throwIfMissing(),
+  bridgeAddress,
+  nRlcAmount,
   { sidechainBridgeAddress, bridgedContracts } = {},
 ) =>
   new Observable((observer) => {
@@ -78,13 +78,17 @@ export const obsBridgeToSidechain = (
         // input validation
         const vBridgeAddress = await addressSchema({
           ethProvider: contracts.provider,
-        }).validate(bridgeAddress);
+        })
+          .required()
+          .validate(bridgeAddress);
         const vSidechainBridgeAddress = sidechainBridgeAddress
           ? await addressSchema({
               ethProvider: contracts.provider,
             }).validate(sidechainBridgeAddress)
           : undefined;
-        const vAmount = await nRlcAmountSchema().validate(nRlcAmount);
+        const vAmount = await nRlcAmountSchema()
+          .required()
+          .validate(nRlcAmount);
         if (contracts.isNative) throw Error('Current chain is a sidechain');
         const balance = await getRlcBalance(
           contracts,
@@ -317,8 +321,8 @@ export const bridgeToSidechain = async (
 
 export const obsBridgeToMainchain = (
   contracts = throwIfMissing(),
-  bridgeAddress = throwIfMissing(),
-  nRlcAmount = throwIfMissing(),
+  bridgeAddress,
+  nRlcAmount,
   { mainchainBridgeAddress, bridgedContracts } = {},
 ) =>
   new Observable((observer) => {
@@ -335,9 +339,13 @@ export const obsBridgeToMainchain = (
         const vMainchainBridgeAddress = mainchainBridgeAddress
           ? await addressSchema({
               ethProvider: contracts.provider,
-            }).validate(mainchainBridgeAddress)
+            })
+              .required()
+              .validate(mainchainBridgeAddress)
           : undefined;
-        const vAmount = await nRlcAmountSchema().validate(nRlcAmount);
+        const vAmount = await nRlcAmountSchema()
+          .required()
+          .validate(nRlcAmount);
         if (!contracts.isNative) throw Error('Current chain is a mainchain');
         const balance = await getRlcBalance(
           contracts,

--- a/src/common/wallet/send.js
+++ b/src/common/wallet/send.js
@@ -21,16 +21,18 @@ const debug = Debug('iexec:wallet:send');
 
 const sendNativeToken = async (
   contracts = throwIfMissing(),
-  value = throwIfMissing(),
-  to = throwIfMissing(),
+  value,
+  to,
   { gasFees = {} } = {},
 ) => {
   try {
     checkSigner(contracts);
     const vAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(to);
-    const vValue = await uint256Schema().validate(value);
+    })
+      .required()
+      .validate(to);
+    const vValue = await uint256Schema().required().validate(value);
     const tx = await wrapSend(
       contracts.signer.sendTransaction({
         data: '0x',
@@ -48,16 +50,14 @@ const sendNativeToken = async (
   }
 };
 
-const sendERC20 = async (
-  contracts = throwIfMissing(),
-  nRlcAmount = throwIfMissing(),
-  to = throwIfMissing(),
-) => {
+const sendERC20 = async (contracts = throwIfMissing(), nRlcAmount, to) => {
   checkSigner(contracts);
   const vAddress = await addressSchema({
     ethProvider: contracts.provider,
-  }).validate(to);
-  const vAmount = await nRlcAmountSchema().validate(nRlcAmount);
+  })
+    .required()
+    .validate(to);
+  const vAmount = await nRlcAmountSchema().required().validate(nRlcAmount);
   try {
     const rlcContract = await wrapCall(contracts.fetchTokenContract());
     const tx = await wrapSend(
@@ -71,17 +71,15 @@ const sendERC20 = async (
   }
 };
 
-export const sendETH = async (
-  contracts = throwIfMissing(),
-  amount = throwIfMissing(),
-  to = throwIfMissing(),
-) => {
+export const sendETH = async (contracts = throwIfMissing(), amount, to) => {
   try {
     checkSigner(contracts);
     const vAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(to);
-    const vAmount = await weiAmountSchema().validate(amount);
+    })
+      .required()
+      .validate(to);
+    const vAmount = await weiAmountSchema().required().validate(amount);
     if (contracts.isNative)
       throw Error('sendETH() is disabled on sidechain, use sendRLC()');
     const balance = await getEthBalance(contracts, await getAddress(contracts));
@@ -95,17 +93,15 @@ export const sendETH = async (
   }
 };
 
-export const sendRLC = async (
-  contracts = throwIfMissing(),
-  nRlcAmount = throwIfMissing(),
-  to = throwIfMissing(),
-) => {
+export const sendRLC = async (contracts = throwIfMissing(), nRlcAmount, to) => {
   try {
     checkSigner(contracts);
     const vAddress = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(to);
-    const vAmount = await nRlcAmountSchema().validate(nRlcAmount);
+    })
+      .required()
+      .validate(to);
+    const vAmount = await nRlcAmountSchema().required().validate(nRlcAmount);
     const balance = await getRlcBalance(contracts, await getAddress(contracts));
     if (balance.lt(new BN(vAmount))) {
       throw Error('Amount to send exceed wallet balance');
@@ -123,15 +119,14 @@ export const sendRLC = async (
   }
 };
 
-export const sweep = async (
-  contracts = throwIfMissing(),
-  to = throwIfMissing(),
-) => {
+export const sweep = async (contracts = throwIfMissing(), to) => {
   try {
     checkSigner(contracts);
     const vAddressTo = await addressSchema({
       ethProvider: contracts.provider,
-    }).validate(to);
+    })
+      .required()
+      .validate(to);
     const userAddress = await getAddress(contracts);
     const code = await contracts.provider.getCode(vAddressTo);
     if (code !== '0x') {

--- a/src/lib/IExecOrderModule.d.ts
+++ b/src/lib/IExecOrderModule.d.ts
@@ -1031,7 +1031,7 @@ export default class IExecOrderModule extends IExecModule {
       /**
        * override the voucher contract to use, must be combined with `useVoucher: true`
        *
-       * the user must be authorized to use the voucher by the voucher's owner
+       * the user must be authorized by the voucher's owner to use it
        */
       voucherAddress?: Addressish;
     },
@@ -1067,11 +1067,11 @@ export default class IExecOrderModule extends IExecModule {
       /**
        * override the voucher contract to use, must be combined with `useVoucher: true`
        *
-       * the user must be authorized to use the voucher by the voucher's owner
+       * the user must be authorized by the voucher's owner to use it
        */
       voucherAddress?: Addressish;
     },
-  ): Promise<{ total: NRlcAmount; sponsored: NRlcAmount }>;
+  ): Promise<{ total: BN; sponsored: BN }>;
   /**
    * Create an IExecOrderModule instance using an IExecConfig instance
    */

--- a/src/lib/IExecOrderModule.d.ts
+++ b/src/lib/IExecOrderModule.d.ts
@@ -1024,7 +1024,16 @@ export default class IExecOrderModule extends IExecModule {
     },
     options?: {
       preflightCheck?: boolean;
+      /**
+       * use a voucher contract to sponsor the deal
+       */
       useVoucher?: boolean;
+      /**
+       * override the voucher contract to use, must be combined with `useVoucher: true`
+       *
+       * the user must be authorized to use the voucher by the voucher's owner
+       */
+      voucherAddress?: Addressish;
     },
   ): Promise<{ dealid: Dealid; volume: BN; txHash: TxHash }>;
   /**
@@ -1051,7 +1060,16 @@ export default class IExecOrderModule extends IExecModule {
       requestorder: ConsumableRequestorder;
     },
     options?: {
+      /**
+       * use a voucher contract to sponsor the deal
+       */
       useVoucher?: boolean;
+      /**
+       * override the voucher contract to use, must be combined with `useVoucher: true`
+       *
+       * the user must be authorized to use the voucher by the voucher's owner
+       */
+      voucherAddress?: Addressish;
     },
   ): Promise<{ total: NRlcAmount; sponsored: NRlcAmount }>;
   /**

--- a/src/lib/IExecOrderModule.js
+++ b/src/lib/IExecOrderModule.js
@@ -329,17 +329,17 @@ export default class IExecOrderModule extends IExecModule {
               .validate(datasetorder)
           ).tag,
         ]);
-        return matchOrders(
+        return matchOrders({
           contracts,
           voucherHubAddress,
-          await checkAppRequirements(
+          apporder: await checkAppRequirements(
             {
               contracts,
             },
             apporder,
             { tagOverride: resolvedTag },
           ).then(() => apporder),
-          await checkDatasetRequirements(
+          datasetorder: await checkDatasetRequirements(
             {
               contracts,
               smsURL: await this.config.resolveSmsURL({
@@ -350,7 +350,7 @@ export default class IExecOrderModule extends IExecModule {
             { tagOverride: resolvedTag },
           ).then(() => datasetorder),
           workerpoolorder,
-          await checkRequestRequirements(
+          requestorder: await checkRequestRequirements(
             {
               contracts,
               smsURL: await this.config.resolveSmsURL({
@@ -360,9 +360,9 @@ export default class IExecOrderModule extends IExecModule {
             requestorder,
           ).then(() => requestorder),
           useVoucher,
-        );
+        });
       }
-      return matchOrders(
+      return matchOrders({
         contracts,
         voucherHubAddress,
         apporder,
@@ -370,7 +370,7 @@ export default class IExecOrderModule extends IExecModule {
         workerpoolorder,
         requestorder,
         useVoucher,
-      );
+      });
     };
 
     this.estimateMatchOrders = async (
@@ -379,7 +379,7 @@ export default class IExecOrderModule extends IExecModule {
     ) => {
       const contracts = await this.config.resolveContractsClient();
       const voucherHubAddress = await this.config.resolveVoucherHubAddress();
-      return estimateMatchOrders(
+      return estimateMatchOrders({
         contracts,
         voucherHubAddress,
         apporder,
@@ -387,7 +387,7 @@ export default class IExecOrderModule extends IExecModule {
         workerpoolorder,
         requestorder,
         useVoucher,
-      );
+      });
     };
   }
 }

--- a/src/lib/IExecOrderModule.js
+++ b/src/lib/IExecOrderModule.js
@@ -308,7 +308,7 @@ export default class IExecOrderModule extends IExecModule {
         workerpoolorder,
         requestorder,
       },
-      { preflightCheck = true, useVoucher = false } = {},
+      { preflightCheck = true, useVoucher = false, voucherAddress } = {},
     ) => {
       const contracts = await this.config.resolveContractsClient();
       let voucherHubAddress;
@@ -360,6 +360,7 @@ export default class IExecOrderModule extends IExecModule {
             requestorder,
           ).then(() => requestorder),
           useVoucher,
+          voucherAddress,
         });
       }
       return matchOrders({
@@ -370,12 +371,13 @@ export default class IExecOrderModule extends IExecModule {
         workerpoolorder,
         requestorder,
         useVoucher,
+        voucherAddress,
       });
     };
 
     this.estimateMatchOrders = async (
       { apporder, datasetorder, workerpoolorder, requestorder },
-      { useVoucher = false } = {},
+      { useVoucher = false, voucherAddress } = {},
     ) => {
       const contracts = await this.config.resolveContractsClient();
       const voucherHubAddress = await this.config.resolveVoucherHubAddress();
@@ -387,6 +389,7 @@ export default class IExecOrderModule extends IExecModule {
         workerpoolorder,
         requestorder,
         useVoucher,
+        voucherAddress,
       });
     };
   }

--- a/test/lib/e2e/IExecOrderModule.test.js
+++ b/test/lib/e2e/IExecOrderModule.test.js
@@ -1716,625 +1716,708 @@ describe('estimateMatchOrders()', () => {
       expect(res.total).toEqual(expectedTotal);
     });
   });
+});
 
-  describe('matchOrders()', () => {
-    test('order.matchOrders() all tests (split TODO)', async () => {
-      const { iexec: iexecBroker } = getTestConfig(iexecTestChain)();
-      const { iexec: iexecPoolManager, wallet: poolManagerWallet } =
-        getTestConfig(iexecTestChain)();
-      const { iexec: iexecRequester, wallet: requesterWallet } =
-        getTestConfig(iexecTestChain)();
-      const { iexec: iexecAppProvider } = getTestConfig(iexecTestChain)();
-      const { iexec: iexecDatasetProvider } = getTestConfig(iexecTestChain)();
+describe('matchOrders()', () => {
+  test('order.matchOrders() all tests (split TODO)', async () => {
+    const { iexec: iexecBroker } = getTestConfig(iexecTestChain)();
+    const { iexec: iexecPoolManager, wallet: poolManagerWallet } =
+      getTestConfig(iexecTestChain)();
+    const { iexec: iexecRequester, wallet: requesterWallet } =
+      getTestConfig(iexecTestChain)();
+    const { iexec: iexecAppProvider } = getTestConfig(iexecTestChain)();
+    const { iexec: iexecDatasetProvider } = getTestConfig(iexecTestChain)();
 
-      await setNRlcBalance(iexecTestChain)(
-        requesterWallet.address,
-        10n * ONE_RLC,
-      );
-      await setNRlcBalance(iexecTestChain)(
-        poolManagerWallet.address,
-        10n * ONE_RLC,
-      );
+    await setNRlcBalance(iexecTestChain)(
+      requesterWallet.address,
+      10n * ONE_RLC,
+    );
+    await setNRlcBalance(iexecTestChain)(
+      poolManagerWallet.address,
+      10n * ONE_RLC,
+    );
 
-      const apporderTemplate = await deployAndGetApporder(iexecAppProvider);
-      const datasetorderTemplate =
-        await deployAndGetDatasetorder(iexecDatasetProvider);
-      const workerpoolorderTemplate =
-        await deployAndGetWorkerpoolorder(iexecPoolManager);
-      const requestorderTemplate = await getMatchableRequestorder(
-        iexecRequester,
+    const apporderTemplate = await deployAndGetApporder(iexecAppProvider);
+    const datasetorderTemplate =
+      await deployAndGetDatasetorder(iexecDatasetProvider);
+    const workerpoolorderTemplate =
+      await deployAndGetWorkerpoolorder(iexecPoolManager);
+    const requestorderTemplate = await getMatchableRequestorder(
+      iexecRequester,
+      {
+        apporder: apporderTemplate,
+        datasetorder: datasetorderTemplate,
+        workerpoolorder: workerpoolorderTemplate,
+      },
+    );
+
+    // resource not deployed
+    const fakeAddress = getRandomAddress();
+    const apporderNotDeployed = { ...apporderTemplate, app: fakeAddress };
+    await expect(
+      iexecBroker.order.matchOrders(
         {
-          apporder: apporderTemplate,
-          datasetorder: datasetorderTemplate,
-          workerpoolorder: workerpoolorderTemplate,
-        },
-      );
-
-      // resource not deployed
-      const fakeAddress = getRandomAddress();
-      const apporderNotDeployed = { ...apporderTemplate, app: fakeAddress };
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderNotDeployed,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderTemplate,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error(`No app deployed at address ${fakeAddress}`));
-      const datasetorderNotDeployed = {
-        ...datasetorderTemplate,
-        dataset: fakeAddress,
-      };
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderNotDeployed,
-            workerpoolorder: workerpoolorderTemplate,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error(`No dataset deployed at address ${fakeAddress}`));
-      const workerpoolorderNotDeployed = {
-        ...workerpoolorderTemplate,
-        workerpool: fakeAddress,
-      };
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderNotDeployed,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(
-        Error(`No workerpool deployed at address ${fakeAddress}`),
-      );
-      // invalid sign
-      const apporderInvalidSign = {
-        ...apporderTemplate,
-        sign: '0xa1d59ea4f4ed84ed1c2fcbdb217f22d64180d95ccaed3268bdfef796ff7f5fa50c2d4c83bf7465afbd9ca292c433495eb573d1f8bcca585cb107b047c899dcb81c',
-      };
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderInvalidSign,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderTemplate,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error('apporder invalid sign'));
-      const datasetorderInvalidSign = {
-        ...datasetorderTemplate,
-        sign: '0xa1d59ea4f4ed84ed1c2fcbdb217f22d64180d95ccaed3268bdfef796ff7f5fa50c2d4c83bf7465afbd9ca292c433495eb573d1f8bcca585cb107b047c899dcb81c',
-      };
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderInvalidSign,
-            workerpoolorder: workerpoolorderTemplate,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error('datasetorder invalid sign'));
-      const workerpoolorderInvalidSign = {
-        ...workerpoolorderTemplate,
-        sign: '0xa1d59ea4f4ed84ed1c2fcbdb217f22d64180d95ccaed3268bdfef796ff7f5fa50c2d4c83bf7465afbd9ca292c433495eb573d1f8bcca585cb107b047c899dcb81c',
-      };
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderInvalidSign,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error('workerpoolorder invalid sign'));
-      const requestorderInvalidSign = {
-        ...requestorderTemplate,
-        sign: '0xa1d59ea4f4ed84ed1c2fcbdb217f22d64180d95ccaed3268bdfef796ff7f5fa50c2d4c83bf7465afbd9ca292c433495eb573d1f8bcca585cb107b047c899dcb81c',
-      };
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderTemplate,
-            requestorder: requestorderInvalidSign,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error('requestorder invalid sign'));
-
-      // address mismatch
-      const apporderAddressMismatch =
-        await deployAndGetApporder(iexecAppProvider);
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderAddressMismatch,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderTemplate,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(
-        Error(
-          `app address mismatch between requestorder (${requestorderTemplate.app}) and apporder (${apporderAddressMismatch.app})`,
-        ),
-      );
-      const datasetorderAddressMismatch =
-        await deployAndGetDatasetorder(iexecDatasetProvider);
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderAddressMismatch,
-            workerpoolorder: workerpoolorderTemplate,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(
-        Error(
-          `dataset address mismatch between requestorder (${requestorderTemplate.dataset}) and datasetorder (${datasetorderAddressMismatch.dataset})`,
-        ),
-      );
-      const workerpoolorderAddressMismatch =
-        await deployAndGetWorkerpoolorder(iexecPoolManager);
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderAddressMismatch,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(
-        Error(
-          `workerpool address mismatch between requestorder (${requestorderTemplate.workerpool}) and workerpoolorder (${workerpoolorderAddressMismatch.workerpool})`,
-        ),
-      );
-      // category check
-      const workerpoolorderCategoryMismatch =
-        await iexecPoolManager.order.signWorkerpoolorder({
-          ...workerpoolorderTemplate,
-          category: 2,
-        });
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderCategoryMismatch,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(
-        Error(
-          `category mismatch between requestorder (${requestorderTemplate.category}) and workerpoolorder (${workerpoolorderCategoryMismatch.category})`,
-        ),
-      );
-      // trust check
-      const workerpoolorderTrustZero =
-        await iexecPoolManager.order.signWorkerpoolorder({
-          ...workerpoolorderTemplate,
-          trust: 0,
-        });
-      const requestorderTrustTooHigh =
-        await iexecRequester.order.signRequestorder(
-          {
-            ...requestorderTemplate,
-            trust: 2,
-          },
-          { preflightCheck: false },
-        );
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderTrustZero,
-            requestorder: requestorderTrustTooHigh,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(
-        Error(
-          `workerpoolorder trust is too low (expected ${requestorderTrustTooHigh.trust}, got ${workerpoolorderTrustZero.trust})`,
-        ),
-      );
-
-      // workerpool tag check
-      const requestorderTagTeeGpu = await iexecRequester.order.signRequestorder(
-        {
-          ...requestorderTemplate,
-          tag: ['tee', 'scone', 'gpu'],
-        },
-        { preflightCheck: false },
-      );
-      const workerpoolorderTagGpu =
-        await iexecPoolManager.order.signWorkerpoolorder({
-          ...workerpoolorderTemplate,
-          tag: ['gpu'],
-        });
-      const workerpoolorderTagTee =
-        await iexecPoolManager.order.signWorkerpoolorder({
-          ...workerpoolorderTemplate,
-          tag: ['tee', 'scone'],
-        });
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderTagGpu,
-            requestorder: requestorderTagTeeGpu,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error('Missing tags [tee,scone] in workerpoolorder'));
-      const apporderTagGpu = await iexecAppProvider.order.signApporder({
-        ...apporderTemplate,
-        tag: ['gpu'],
-      });
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTagGpu,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderTagTee,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error('Missing tags [gpu] in workerpoolorder'));
-      const datasetorderTagTeeGpu =
-        await iexecDatasetProvider.order.signDatasetorder(
-          {
-            ...datasetorderTemplate,
-            tag: ['gpu', 'tee', 'scone'],
-          },
-          { preflightCheck: false },
-        );
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderTagTeeGpu,
-            workerpoolorder: workerpoolorderTagTee,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error('Missing tags [gpu] in workerpoolorder'));
-      // app tag check
-      const datasetorderTagTee =
-        await iexecDatasetProvider.order.signDatasetorder(
-          {
-            ...datasetorderTemplate,
-            tag: ['tee', 'scone'],
-          },
-          { preflightCheck: false },
-        );
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderTagTee,
-            workerpoolorder: workerpoolorderTagTee,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error('Missing tag [tee] in apporder'));
-      // price check
-      const apporderTooExpensive = await iexecAppProvider.order.signApporder({
-        ...apporderTemplate,
-        appprice: 1,
-      });
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTooExpensive,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderTemplate,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(
-        Error(
-          `appmaxprice too low (expected ${apporderTooExpensive.appprice}, got ${requestorderTemplate.appmaxprice})`,
-        ),
-      );
-
-      const datasetorderTooExpensive =
-        await iexecDatasetProvider.order.signDatasetorder(
-          {
-            ...datasetorderTemplate,
-            datasetprice: 1,
-          },
-          { preflightCheck: false },
-        );
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderTooExpensive,
-            workerpoolorder: workerpoolorderTemplate,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(
-        Error(
-          `datasetmaxprice too low (expected ${datasetorderTooExpensive.datasetprice}, got ${requestorderTemplate.datasetmaxprice})`,
-        ),
-      );
-
-      const workerpoolorderTooExpensive =
-        await iexecPoolManager.order.signWorkerpoolorder({
-          ...workerpoolorderTemplate,
-          workerpoolprice: 1,
-        });
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderTooExpensive,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(
-        Error(
-          `workerpoolmaxprice too low (expected ${workerpoolorderTooExpensive.workerpoolprice}, got ${requestorderTemplate.workerpoolmaxprice})`,
-        ),
-      );
-      // volumes checks
-      const apporderCanceled = await iexecAppProvider.order
-        .signApporder(apporderTemplate, { preflightCheck: false })
-        .then(async (order) => {
-          await iexecAppProvider.order.cancelApporder(order);
-          return order;
-        });
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderCanceled,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderTemplate,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error('apporder is fully consumed'));
-
-      const datasetorderCanceled = await iexecDatasetProvider.order
-        .signDatasetorder(datasetorderTemplate, { preflightCheck: false })
-        .then(async (order) => {
-          await iexecDatasetProvider.order.cancelDatasetorder(order);
-          return order;
-        });
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderCanceled,
-            workerpoolorder: workerpoolorderTemplate,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error('datasetorder is fully consumed'));
-
-      const workerpoolorderCanceled = await iexecPoolManager.order
-        .signWorkerpoolorder(workerpoolorderTemplate)
-        .then(async (order) => {
-          await iexecPoolManager.order.cancelWorkerpoolorder(order);
-          return order;
-        });
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderCanceled,
-            requestorder: requestorderTemplate,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error('workerpoolorder is fully consumed'));
-      const requestorderCanceled = await iexecRequester.order
-        .signRequestorder(requestorderTemplate, { preflightCheck: false })
-        .then(async (order) => {
-          await iexecRequester.order.cancelRequestorder(order);
-          return order;
-        });
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderTemplate,
-            requestorder: requestorderCanceled,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error('requestorder is fully consumed'));
-
-      // requester account stake check
-      const balance = await iexecRequester.account.checkBalance(
-        await iexecRequester.wallet.getAddress(),
-      );
-      await iexecRequester.account.withdraw(balance.stake).catch(() => {});
-      await iexecRequester.account.deposit(5);
-
-      const apporder3nRlc = await iexecAppProvider.order.signApporder(
-        {
-          ...apporderTemplate,
-          appprice: 3,
-        },
-        { preflightCheck: false },
-      );
-      const datasetorder2nRlc =
-        await iexecDatasetProvider.order.signDatasetorder(
-          {
-            ...datasetorderTemplate,
-            datasetprice: 2,
-          },
-          { preflightCheck: false },
-        );
-      const workerpoolorder1nRlc =
-        await iexecPoolManager.order.signWorkerpoolorder({
-          ...workerpoolorderTemplate,
-          workerpoolprice: 1,
-        });
-      const requestorder300nRlc = await iexecRequester.order.signRequestorder(
-        {
-          ...requestorderTemplate,
-          appmaxprice: 100,
-          datasetmaxprice: 100,
-          workerpoolmaxprice: 100,
-        },
-        { preflightCheck: false },
-      );
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporder3nRlc,
-            datasetorder: datasetorder2nRlc,
-            workerpoolorder: workerpoolorder1nRlc,
-            requestorder: requestorder300nRlc,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(
-        Error(
-          "Cost per task (6) is greater than requester account stake (5). Orders can't be matched. If you are the requester, you should deposit to top up your account",
-        ),
-      );
-
-      const apporder0nRlc = await iexecAppProvider.order.signApporder(
-        {
-          ...apporderTemplate,
-          appprice: 0,
-          volume: 1000,
-        },
-        { preflightCheck: false },
-      );
-      const datasetorder0nRlc =
-        await iexecDatasetProvider.order.signDatasetorder(
-          {
-            ...datasetorderTemplate,
-            datasetprice: 0,
-            volume: 1000,
-          },
-          { preflightCheck: false },
-        );
-      const workerpoolorder2nRlc =
-        await iexecPoolManager.order.signWorkerpoolorder({
-          ...workerpoolorderTemplate,
-          workerpoolprice: 2,
-          volume: 1000,
-        });
-      const requestorder6nRlc = await iexecRequester.order.signRequestorder(
-        {
-          ...requestorderTemplate,
-          workerpoolmaxprice: 2,
-          volume: 3,
-        },
-        { preflightCheck: false },
-      );
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporder0nRlc,
-            datasetorder: datasetorder0nRlc,
-            workerpoolorder: workerpoolorder2nRlc,
-            requestorder: requestorder6nRlc,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(
-        Error(
-          "Total cost for 3 tasks (6) is greater than requester account stake (5). Orders can't be matched. If you are the requester, you should deposit to top up your account or reduce your requestorder volume",
-        ),
-      );
-      // workerpool owner stake check
-      const workerpoolorder7nRlc =
-        await iexecPoolManager.order.signWorkerpoolorder({
-          ...workerpoolorderTemplate,
-          workerpoolprice: 7,
-        });
-      await iexecRequester.account.deposit(10);
-      const poolManagerBalance = await iexecPoolManager.account.checkBalance(
-        await iexecPoolManager.wallet.getAddress(),
-      );
-      await iexecPoolManager.account
-        .withdraw(poolManagerBalance.stake)
-        .catch(() => {});
-
-      await iexecPoolManager.account.deposit(1);
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporder3nRlc,
-            datasetorder: datasetorder2nRlc,
-            workerpoolorder: workerpoolorder7nRlc,
-            requestorder: requestorder300nRlc,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(
-        Error(
-          "workerpool required stake (2) is greater than workerpool owner's account stake (1). Orders can't be matched. If you are the workerpool owner, you should deposit to top up your account",
-        ),
-      );
-      // standard case
-      const res = await iexecBroker.order.matchOrders(
-        {
-          apporder: apporderTemplate,
+          apporder: apporderNotDeployed,
           datasetorder: datasetorderTemplate,
           workerpoolorder: workerpoolorderTemplate,
           requestorder: requestorderTemplate,
         },
         { preflightCheck: false },
+      ),
+    ).rejects.toThrow(Error(`No app deployed at address ${fakeAddress}`));
+    const datasetorderNotDeployed = {
+      ...datasetorderTemplate,
+      dataset: fakeAddress,
+    };
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderNotDeployed,
+          workerpoolorder: workerpoolorderTemplate,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(Error(`No dataset deployed at address ${fakeAddress}`));
+    const workerpoolorderNotDeployed = {
+      ...workerpoolorderTemplate,
+      workerpool: fakeAddress,
+    };
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderTemplate,
+          workerpoolorder: workerpoolorderNotDeployed,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(
+      Error(`No workerpool deployed at address ${fakeAddress}`),
+    );
+    // invalid sign
+    const apporderInvalidSign = {
+      ...apporderTemplate,
+      sign: '0xa1d59ea4f4ed84ed1c2fcbdb217f22d64180d95ccaed3268bdfef796ff7f5fa50c2d4c83bf7465afbd9ca292c433495eb573d1f8bcca585cb107b047c899dcb81c',
+    };
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderInvalidSign,
+          datasetorder: datasetorderTemplate,
+          workerpoolorder: workerpoolorderTemplate,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(Error('apporder invalid sign'));
+    const datasetorderInvalidSign = {
+      ...datasetorderTemplate,
+      sign: '0xa1d59ea4f4ed84ed1c2fcbdb217f22d64180d95ccaed3268bdfef796ff7f5fa50c2d4c83bf7465afbd9ca292c433495eb573d1f8bcca585cb107b047c899dcb81c',
+    };
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderInvalidSign,
+          workerpoolorder: workerpoolorderTemplate,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(Error('datasetorder invalid sign'));
+    const workerpoolorderInvalidSign = {
+      ...workerpoolorderTemplate,
+      sign: '0xa1d59ea4f4ed84ed1c2fcbdb217f22d64180d95ccaed3268bdfef796ff7f5fa50c2d4c83bf7465afbd9ca292c433495eb573d1f8bcca585cb107b047c899dcb81c',
+    };
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderTemplate,
+          workerpoolorder: workerpoolorderInvalidSign,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(Error('workerpoolorder invalid sign'));
+    const requestorderInvalidSign = {
+      ...requestorderTemplate,
+      sign: '0xa1d59ea4f4ed84ed1c2fcbdb217f22d64180d95ccaed3268bdfef796ff7f5fa50c2d4c83bf7465afbd9ca292c433495eb573d1f8bcca585cb107b047c899dcb81c',
+    };
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderTemplate,
+          workerpoolorder: workerpoolorderTemplate,
+          requestorder: requestorderInvalidSign,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(Error('requestorder invalid sign'));
+
+    // address mismatch
+    const apporderAddressMismatch =
+      await deployAndGetApporder(iexecAppProvider);
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderAddressMismatch,
+          datasetorder: datasetorderTemplate,
+          workerpoolorder: workerpoolorderTemplate,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(
+      Error(
+        `app address mismatch between requestorder (${requestorderTemplate.app}) and apporder (${apporderAddressMismatch.app})`,
+      ),
+    );
+    const datasetorderAddressMismatch =
+      await deployAndGetDatasetorder(iexecDatasetProvider);
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderAddressMismatch,
+          workerpoolorder: workerpoolorderTemplate,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(
+      Error(
+        `dataset address mismatch between requestorder (${requestorderTemplate.dataset}) and datasetorder (${datasetorderAddressMismatch.dataset})`,
+      ),
+    );
+    const workerpoolorderAddressMismatch =
+      await deployAndGetWorkerpoolorder(iexecPoolManager);
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderTemplate,
+          workerpoolorder: workerpoolorderAddressMismatch,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(
+      Error(
+        `workerpool address mismatch between requestorder (${requestorderTemplate.workerpool}) and workerpoolorder (${workerpoolorderAddressMismatch.workerpool})`,
+      ),
+    );
+    // category check
+    const workerpoolorderCategoryMismatch =
+      await iexecPoolManager.order.signWorkerpoolorder({
+        ...workerpoolorderTemplate,
+        category: 2,
+      });
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderTemplate,
+          workerpoolorder: workerpoolorderCategoryMismatch,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(
+      Error(
+        `category mismatch between requestorder (${requestorderTemplate.category}) and workerpoolorder (${workerpoolorderCategoryMismatch.category})`,
+      ),
+    );
+    // trust check
+    const workerpoolorderTrustZero =
+      await iexecPoolManager.order.signWorkerpoolorder({
+        ...workerpoolorderTemplate,
+        trust: 0,
+      });
+    const requestorderTrustTooHigh =
+      await iexecRequester.order.signRequestorder(
+        {
+          ...requestorderTemplate,
+          trust: 2,
+        },
+        { preflightCheck: false },
       );
-      expect(res.txHash).toBeTxHash();
-      expect(res.volume).toBeInstanceOf(BN);
-      expect(res.volume.eq(new BN(1))).toBe(true);
-      expect(res.dealid).toBeTxHash();
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderTemplate,
+          workerpoolorder: workerpoolorderTrustZero,
+          requestorder: requestorderTrustTooHigh,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(
+      Error(
+        `workerpoolorder trust is too low (expected ${requestorderTrustTooHigh.trust}, got ${workerpoolorderTrustZero.trust})`,
+      ),
+    );
+
+    // workerpool tag check
+    const requestorderTagTeeGpu = await iexecRequester.order.signRequestorder(
+      {
+        ...requestorderTemplate,
+        tag: ['tee', 'scone', 'gpu'],
+      },
+      { preflightCheck: false },
+    );
+    const workerpoolorderTagGpu =
+      await iexecPoolManager.order.signWorkerpoolorder({
+        ...workerpoolorderTemplate,
+        tag: ['gpu'],
+      });
+    const workerpoolorderTagTee =
+      await iexecPoolManager.order.signWorkerpoolorder({
+        ...workerpoolorderTemplate,
+        tag: ['tee', 'scone'],
+      });
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderTemplate,
+          workerpoolorder: workerpoolorderTagGpu,
+          requestorder: requestorderTagTeeGpu,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(Error('Missing tags [tee,scone] in workerpoolorder'));
+    const apporderTagGpu = await iexecAppProvider.order.signApporder({
+      ...apporderTemplate,
+      tag: ['gpu'],
+    });
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTagGpu,
+          datasetorder: datasetorderTemplate,
+          workerpoolorder: workerpoolorderTagTee,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(Error('Missing tags [gpu] in workerpoolorder'));
+    const datasetorderTagTeeGpu =
+      await iexecDatasetProvider.order.signDatasetorder(
+        {
+          ...datasetorderTemplate,
+          tag: ['gpu', 'tee', 'scone'],
+        },
+        { preflightCheck: false },
+      );
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderTagTeeGpu,
+          workerpoolorder: workerpoolorderTagTee,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(Error('Missing tags [gpu] in workerpoolorder'));
+    // app tag check
+    const datasetorderTagTee =
+      await iexecDatasetProvider.order.signDatasetorder(
+        {
+          ...datasetorderTemplate,
+          tag: ['tee', 'scone'],
+        },
+        { preflightCheck: false },
+      );
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderTagTee,
+          workerpoolorder: workerpoolorderTagTee,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(Error('Missing tag [tee] in apporder'));
+    // price check
+    const apporderTooExpensive = await iexecAppProvider.order.signApporder({
+      ...apporderTemplate,
+      appprice: 1,
+    });
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTooExpensive,
+          datasetorder: datasetorderTemplate,
+          workerpoolorder: workerpoolorderTemplate,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(
+      Error(
+        `appmaxprice too low (expected ${apporderTooExpensive.appprice}, got ${requestorderTemplate.appmaxprice})`,
+      ),
+    );
+
+    const datasetorderTooExpensive =
+      await iexecDatasetProvider.order.signDatasetorder(
+        {
+          ...datasetorderTemplate,
+          datasetprice: 1,
+        },
+        { preflightCheck: false },
+      );
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderTooExpensive,
+          workerpoolorder: workerpoolorderTemplate,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(
+      Error(
+        `datasetmaxprice too low (expected ${datasetorderTooExpensive.datasetprice}, got ${requestorderTemplate.datasetmaxprice})`,
+      ),
+    );
+
+    const workerpoolorderTooExpensive =
+      await iexecPoolManager.order.signWorkerpoolorder({
+        ...workerpoolorderTemplate,
+        workerpoolprice: 1,
+      });
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderTemplate,
+          workerpoolorder: workerpoolorderTooExpensive,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(
+      Error(
+        `workerpoolmaxprice too low (expected ${workerpoolorderTooExpensive.workerpoolprice}, got ${requestorderTemplate.workerpoolmaxprice})`,
+      ),
+    );
+    // volumes checks
+    const apporderCanceled = await iexecAppProvider.order
+      .signApporder(apporderTemplate, { preflightCheck: false })
+      .then(async (order) => {
+        await iexecAppProvider.order.cancelApporder(order);
+        return order;
+      });
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderCanceled,
+          datasetorder: datasetorderTemplate,
+          workerpoolorder: workerpoolorderTemplate,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(Error('apporder is fully consumed'));
+
+    const datasetorderCanceled = await iexecDatasetProvider.order
+      .signDatasetorder(datasetorderTemplate, { preflightCheck: false })
+      .then(async (order) => {
+        await iexecDatasetProvider.order.cancelDatasetorder(order);
+        return order;
+      });
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderCanceled,
+          workerpoolorder: workerpoolorderTemplate,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(Error('datasetorder is fully consumed'));
+
+    const workerpoolorderCanceled = await iexecPoolManager.order
+      .signWorkerpoolorder(workerpoolorderTemplate)
+      .then(async (order) => {
+        await iexecPoolManager.order.cancelWorkerpoolorder(order);
+        return order;
+      });
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderTemplate,
+          workerpoolorder: workerpoolorderCanceled,
+          requestorder: requestorderTemplate,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(Error('workerpoolorder is fully consumed'));
+    const requestorderCanceled = await iexecRequester.order
+      .signRequestorder(requestorderTemplate, { preflightCheck: false })
+      .then(async (order) => {
+        await iexecRequester.order.cancelRequestorder(order);
+        return order;
+      });
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporderTemplate,
+          datasetorder: datasetorderTemplate,
+          workerpoolorder: workerpoolorderTemplate,
+          requestorder: requestorderCanceled,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(Error('requestorder is fully consumed'));
+
+    // requester account stake check
+    const balance = await iexecRequester.account.checkBalance(
+      await iexecRequester.wallet.getAddress(),
+    );
+    await iexecRequester.account.withdraw(balance.stake).catch(() => {});
+    await iexecRequester.account.deposit(5);
+
+    const apporder3nRlc = await iexecAppProvider.order.signApporder(
+      {
+        ...apporderTemplate,
+        appprice: 3,
+      },
+      { preflightCheck: false },
+    );
+    const datasetorder2nRlc = await iexecDatasetProvider.order.signDatasetorder(
+      {
+        ...datasetorderTemplate,
+        datasetprice: 2,
+      },
+      { preflightCheck: false },
+    );
+    const workerpoolorder1nRlc =
+      await iexecPoolManager.order.signWorkerpoolorder({
+        ...workerpoolorderTemplate,
+        workerpoolprice: 1,
+      });
+    const requestorder300nRlc = await iexecRequester.order.signRequestorder(
+      {
+        ...requestorderTemplate,
+        appmaxprice: 100,
+        datasetmaxprice: 100,
+        workerpoolmaxprice: 100,
+      },
+      { preflightCheck: false },
+    );
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporder3nRlc,
+          datasetorder: datasetorder2nRlc,
+          workerpoolorder: workerpoolorder1nRlc,
+          requestorder: requestorder300nRlc,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(
+      Error(
+        "Cost per task (6) is greater than requester account stake (5). Orders can't be matched. If you are the requester, you should deposit to top up your account",
+      ),
+    );
+
+    const apporder0nRlc = await iexecAppProvider.order.signApporder(
+      {
+        ...apporderTemplate,
+        appprice: 0,
+        volume: 1000,
+      },
+      { preflightCheck: false },
+    );
+    const datasetorder0nRlc = await iexecDatasetProvider.order.signDatasetorder(
+      {
+        ...datasetorderTemplate,
+        datasetprice: 0,
+        volume: 1000,
+      },
+      { preflightCheck: false },
+    );
+    const workerpoolorder2nRlc =
+      await iexecPoolManager.order.signWorkerpoolorder({
+        ...workerpoolorderTemplate,
+        workerpoolprice: 2,
+        volume: 1000,
+      });
+    const requestorder6nRlc = await iexecRequester.order.signRequestorder(
+      {
+        ...requestorderTemplate,
+        workerpoolmaxprice: 2,
+        volume: 3,
+      },
+      { preflightCheck: false },
+    );
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporder0nRlc,
+          datasetorder: datasetorder0nRlc,
+          workerpoolorder: workerpoolorder2nRlc,
+          requestorder: requestorder6nRlc,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(
+      Error(
+        "Total cost for 3 tasks (6) is greater than requester account stake (5). Orders can't be matched. If you are the requester, you should deposit to top up your account or reduce your requestorder volume",
+      ),
+    );
+    // workerpool owner stake check
+    const workerpoolorder7nRlc =
+      await iexecPoolManager.order.signWorkerpoolorder({
+        ...workerpoolorderTemplate,
+        workerpoolprice: 7,
+      });
+    await iexecRequester.account.deposit(10);
+    const poolManagerBalance = await iexecPoolManager.account.checkBalance(
+      await iexecPoolManager.wallet.getAddress(),
+    );
+    await iexecPoolManager.account
+      .withdraw(poolManagerBalance.stake)
+      .catch(() => {});
+
+    await iexecPoolManager.account.deposit(1);
+    await expect(
+      iexecBroker.order.matchOrders(
+        {
+          apporder: apporder3nRlc,
+          datasetorder: datasetorder2nRlc,
+          workerpoolorder: workerpoolorder7nRlc,
+          requestorder: requestorder300nRlc,
+        },
+        { preflightCheck: false },
+      ),
+    ).rejects.toThrow(
+      Error(
+        "workerpool required stake (2) is greater than workerpool owner's account stake (1). Orders can't be matched. If you are the workerpool owner, you should deposit to top up your account",
+      ),
+    );
+    // standard case
+    const res = await iexecBroker.order.matchOrders(
+      {
+        apporder: apporderTemplate,
+        datasetorder: datasetorderTemplate,
+        workerpoolorder: workerpoolorderTemplate,
+        requestorder: requestorderTemplate,
+      },
+      { preflightCheck: false },
+    );
+    expect(res.txHash).toBeTxHash();
+    expect(res.volume).toBeInstanceOf(BN);
+    expect(res.volume.eq(new BN(1))).toBe(true);
+    expect(res.dealid).toBeTxHash();
+  });
+
+  test('preflightChecks', async () => {
+    const { iexec: iexecRequester } = getTestConfig(iexecTestChain)();
+    const { iexec: iexecResourcesProvider } = getTestConfig(iexecTestChain)();
+
+    const apporder = await deployAndGetApporder(iexecResourcesProvider);
+    const datasetorder = await deployAndGetDatasetorder(iexecResourcesProvider);
+    const workerpoolorder = await deployAndGetWorkerpoolorder(
+      iexecResourcesProvider,
+    );
+    const requestorder = await getMatchableRequestorder(iexecRequester, {
+      apporder,
+      datasetorder,
+      workerpoolorder,
     });
 
-    test('preflightChecks', async () => {
-      const { iexec: iexecRequester } = getTestConfig(iexecTestChain)();
+    const teeApporder = await deployAndGetApporder(iexecResourcesProvider, {
+      teeFramework: TEE_FRAMEWORKS.SCONE,
+      tag: ['tee', 'scone'],
+    });
+    const teeDatasetorder = await deployAndGetDatasetorder(
+      iexecResourcesProvider,
+      { tag: ['tee', 'scone'] },
+    );
+    const teeWorkerpoolorder = await deployAndGetWorkerpoolorder(
+      iexecResourcesProvider,
+      {
+        tag: ['tee', 'scone'],
+      },
+    );
+    const res = await iexecRequester.order.matchOrders({
+      apporder,
+      datasetorder,
+      workerpoolorder,
+      requestorder,
+    });
+    expect(res.txHash).toBeTxHash();
+    expect(res.volume).toBeInstanceOf(BN);
+    expect(res.volume.eq(new BN(1))).toBe(true);
+    expect(res.dealid).toBeTxHash();
+
+    // trigger app check
+    await expect(
+      iexecRequester.order.matchOrders({
+        apporder,
+        datasetorder,
+        workerpoolorder: teeWorkerpoolorder,
+        requestorder: await getMatchableRequestorder(iexecRequester, {
+          apporder,
+          datasetorder,
+          workerpoolorder: teeWorkerpoolorder,
+        }).then((o) =>
+          iexecRequester.order.signRequestorder(
+            { ...o, tag: ['tee', 'scone'] },
+            { preflightCheck: false },
+          ),
+        ),
+      }),
+    ).rejects.toThrow(Error('Tag mismatch the TEE framework specified by app'));
+
+    // trigger dataset check
+    await expect(
+      iexecRequester.order.matchOrders({
+        apporder: teeApporder,
+        datasetorder: teeDatasetorder,
+        workerpoolorder: teeWorkerpoolorder,
+        requestorder: await getMatchableRequestorder(iexecRequester, {
+          apporder: teeApporder,
+          datasetorder: teeDatasetorder,
+          workerpoolorder: teeWorkerpoolorder,
+        }),
+      }),
+    ).rejects.toThrow('Dataset encryption key is not set for dataset ');
+  });
+
+  describe('useVoucher option', () => {
+    test('should throw error if no voucher available for the requester', async () => {
+      const { iexec: iexecRequester, wallet: requesterWallet } =
+        getTestConfig(iexecTestChain)();
       const { iexec: iexecResourcesProvider } = getTestConfig(iexecTestChain)();
 
-      const apporder = await deployAndGetApporder(iexecResourcesProvider);
+      const apporder = await deployAndGetApporder(iexecResourcesProvider, {
+        volume: 10,
+        appprice: 5,
+      });
       const datasetorder = await deployAndGetDatasetorder(
         iexecResourcesProvider,
+        {
+          volume: 7,
+          datasetprice: 1,
+        },
       );
       const workerpoolorder = await deployAndGetWorkerpoolorder(
         iexecResourcesProvider,
+        { volume: 5, workerpoolprice: 1 },
       );
       const requestorder = await getMatchableRequestorder(iexecRequester, {
         apporder,
@@ -2342,305 +2425,8 @@ describe('estimateMatchOrders()', () => {
         workerpoolorder,
       });
 
-      const teeApporder = await deployAndGetApporder(iexecResourcesProvider, {
-        teeFramework: TEE_FRAMEWORKS.SCONE,
-        tag: ['tee', 'scone'],
-      });
-      const teeDatasetorder = await deployAndGetDatasetorder(
-        iexecResourcesProvider,
-        { tag: ['tee', 'scone'] },
-      );
-      const teeWorkerpoolorder = await deployAndGetWorkerpoolorder(
-        iexecResourcesProvider,
-        {
-          tag: ['tee', 'scone'],
-        },
-      );
-      const res = await iexecRequester.order.matchOrders({
-        apporder,
-        datasetorder,
-        workerpoolorder,
-        requestorder,
-      });
-      expect(res.txHash).toBeTxHash();
-      expect(res.volume).toBeInstanceOf(BN);
-      expect(res.volume.eq(new BN(1))).toBe(true);
-      expect(res.dealid).toBeTxHash();
-
-      // trigger app check
       await expect(
-        iexecRequester.order.matchOrders({
-          apporder,
-          datasetorder,
-          workerpoolorder: teeWorkerpoolorder,
-          requestorder: await getMatchableRequestorder(iexecRequester, {
-            apporder,
-            datasetorder,
-            workerpoolorder: teeWorkerpoolorder,
-          }).then((o) =>
-            iexecRequester.order.signRequestorder(
-              { ...o, tag: ['tee', 'scone'] },
-              { preflightCheck: false },
-            ),
-          ),
-        }),
-      ).rejects.toThrow(
-        Error('Tag mismatch the TEE framework specified by app'),
-      );
-
-      // trigger dataset check
-      await expect(
-        iexecRequester.order.matchOrders({
-          apporder: teeApporder,
-          datasetorder: teeDatasetorder,
-          workerpoolorder: teeWorkerpoolorder,
-          requestorder: await getMatchableRequestorder(iexecRequester, {
-            apporder: teeApporder,
-            datasetorder: teeDatasetorder,
-            workerpoolorder: teeWorkerpoolorder,
-          }),
-        }),
-      ).rejects.toThrow('Dataset encryption key is not set for dataset ');
-    });
-
-    describe('useVoucher option', () => {
-      test('should throw error if no voucher available for the requester', async () => {
-        const { iexec: iexecRequester, wallet: requesterWallet } =
-          getTestConfig(iexecTestChain)();
-        const { iexec: iexecResourcesProvider } =
-          getTestConfig(iexecTestChain)();
-
-        const apporder = await deployAndGetApporder(iexecResourcesProvider, {
-          volume: 10,
-          appprice: 5,
-        });
-        const datasetorder = await deployAndGetDatasetorder(
-          iexecResourcesProvider,
-          {
-            volume: 7,
-            datasetprice: 1,
-          },
-        );
-        const workerpoolorder = await deployAndGetWorkerpoolorder(
-          iexecResourcesProvider,
-          { volume: 5, workerpoolprice: 1 },
-        );
-        const requestorder = await getMatchableRequestorder(iexecRequester, {
-          apporder,
-          datasetorder,
-          workerpoolorder,
-        });
-
-        await expect(
-          iexecRequester.order.matchOrders(
-            {
-              apporder,
-              datasetorder,
-              workerpoolorder,
-              requestorder,
-            },
-            { useVoucher: true },
-          ),
-        ).rejects.toThrow(
-          Error(
-            `No voucher available for the requester ${requesterWallet.address}`,
-          ),
-        );
-      });
-
-      test('requires voucherHubAddress to be configured when useVoucher is true', async () => {
-        const noVoucherTestChain = TEST_CHAINS['custom-token-chain'];
-        const options = {
-          resultProxyURL: 'https://result-proxy.iex.ec',
-          smsURL: 'https://sms.iex.ec',
-        };
-        const { iexec: iexecRequester, wallet: requesterWallet } =
-          getTestConfig(noVoucherTestChain)({
-            options,
-          });
-        const { iexec: iexecResourcesProvider, wallet: providerWallet } =
-          getTestConfig(noVoucherTestChain)({
-            options,
-          });
-
-        await setBalance(noVoucherTestChain)(requesterWallet.address, ONE_ETH);
-        await setBalance(noVoucherTestChain)(providerWallet.address, ONE_ETH);
-
-        const apporder = await deployAndGetApporder(iexecResourcesProvider, {
-          volume: 10,
-          appprice: 5,
-        });
-        const datasetorder = await deployAndGetDatasetorder(
-          iexecResourcesProvider,
-          {
-            volume: 7,
-            datasetprice: 1,
-          },
-        );
-        const workerpoolorder = await deployAndGetWorkerpoolorder(
-          iexecResourcesProvider,
-          { volume: 5, workerpoolprice: 1 },
-        );
-        const requestorder = await getMatchableRequestorder(iexecRequester, {
-          apporder,
-          datasetorder,
-          workerpoolorder,
-        });
-
-        await setNRlcBalance(noVoucherTestChain)(requesterWallet.address, 100);
-        await iexecRequester.account.deposit(100);
-        await expect(
-          iexecRequester.order.matchOrders(
-            {
-              apporder,
-              datasetorder,
-              workerpoolorder,
-              requestorder,
-            },
-            { useVoucher: true },
-          ),
-        ).rejects.toThrow(
-          new ConfigurationError(
-            `voucherHubAddress option not set and no default value for your chain ${noVoucherTestChain.chainId}`,
-          ),
-        );
-        // match orders without useVoucher should pass
-        const res = await iexecRequester.order.matchOrders(
-          {
-            apporder,
-            datasetorder,
-            workerpoolorder,
-            requestorder,
-          },
-          { useVoucher: false },
-        );
-        expect(res.txHash).toBeTxHash();
-        expect(res.volume).toBeInstanceOf(BN);
-        expect(res.volume.eq(new BN(5))).toBe(true);
-        expect(res.dealid).toBeTxHash();
-      });
-
-      test('should throw error for insufficient voucher allowance', async () => {
-        const { iexec: iexecRequester, wallet: requesterWallet } =
-          getTestConfig(iexecTestChain)();
-        const { iexec: iexecResourcesProvider } =
-          getTestConfig(iexecTestChain)();
-
-        const apporder = await deployAndGetApporder(iexecResourcesProvider, {
-          volume: 10,
-          appprice: 5,
-        });
-        const datasetorder = await deployAndGetDatasetorder(
-          iexecResourcesProvider,
-          {
-            volume: 7,
-            datasetprice: 1,
-          },
-        );
-        const workerpoolorder = await deployAndGetWorkerpoolorder(
-          iexecResourcesProvider,
-          { volume: 5, workerpoolprice: 1 },
-        );
-        const requestorder = await getMatchableRequestorder(iexecRequester, {
-          apporder,
-          datasetorder,
-          workerpoolorder,
-        });
-        const voucherTypeId = await createVoucherType(iexecTestChain)({
-          description: 'test voucher type',
-          duration: 42,
-        });
-        await addVoucherEligibleAsset(iexecTestChain)(
-          datasetorder.dataset,
-          voucherTypeId,
-        );
-        await addVoucherEligibleAsset(iexecTestChain)(
-          workerpoolorder.workerpool,
-          voucherTypeId,
-        );
-        const voucherAddress = await createVoucher(iexecTestChain)({
-          owner: await requesterWallet.getAddress(),
-          voucherType: voucherTypeId,
-          value: 1000,
-        });
-        const allowance = await iexecRequester.account.checkAllowance(
-          requestorder.requester,
-          voucherAddress,
-        );
-        const { total, sponsored } =
-          await iexecRequester.order.estimateMatchOrders(
-            { apporder, datasetorder, workerpoolorder, requestorder },
-            { preflightCheck: true, useVoucher: true },
-          );
-
-        const requiredAmount = total.sub(sponsored);
-        const missingAmount = requiredAmount.sub(allowance);
-
-        await expect(
-          iexecRequester.order.matchOrders(
-            {
-              apporder,
-              datasetorder,
-              workerpoolorder,
-              requestorder,
-            },
-            { useVoucher: true },
-          ),
-        ).rejects.toThrow(
-          Error(
-            `Orders can't be matched. Please approve an additional ${missingAmount} for voucher usage.`,
-          ),
-        );
-      });
-
-      test('should match orders with voucher when user deposits to cover the missing amount', async () => {
-        const { iexec: iexecRequester, wallet: requesterWallet } =
-          getTestConfig(iexecTestChain)();
-        const { iexec: iexecResourcesProvider } =
-          getTestConfig(iexecTestChain)();
-
-        const apporder = await deployAndGetApporder(iexecResourcesProvider, {
-          volume: 10,
-          appprice: 5,
-        });
-        const datasetorder = await deployAndGetDatasetorder(
-          iexecResourcesProvider,
-          {
-            volume: 7,
-            datasetprice: 1,
-          },
-        );
-        const workerpoolorder = await deployAndGetWorkerpoolorder(
-          iexecResourcesProvider,
-          { volume: 5, workerpoolprice: 1 },
-        );
-        const requestorder = await getMatchableRequestorder(iexecRequester, {
-          apporder,
-          datasetorder,
-          workerpoolorder,
-        });
-        const voucherTypeId = await createVoucherType(iexecTestChain)({
-          description: 'test voucher type',
-          duration: 42,
-        });
-        await addVoucherEligibleAsset(iexecTestChain)(
-          datasetorder.dataset,
-          voucherTypeId,
-        );
-        await addVoucherEligibleAsset(iexecTestChain)(
-          workerpoolorder.workerpool,
-          voucherTypeId,
-        );
-
-        const voucherAddress = await createVoucher(iexecTestChain)({
-          owner: await requesterWallet.getAddress(),
-          voucherType: voucherTypeId,
-          value: 1000,
-        });
-        await setNRlcBalance(iexecTestChain)(requesterWallet.address, 30);
-        await iexecRequester.account.deposit(30);
-        await iexecRequester.account.approve(25, voucherAddress);
-        const res = await iexecRequester.order.matchOrders(
+        iexecRequester.order.matchOrders(
           {
             apporder,
             datasetorder,
@@ -2648,12 +2434,218 @@ describe('estimateMatchOrders()', () => {
             requestorder,
           },
           { useVoucher: true },
-        );
-        expect(res.txHash).toBeTxHash();
-        expect(res.volume).toBeInstanceOf(BN);
-        expect(res.volume.eq(new BN(5))).toBe(true);
-        expect(res.dealid).toBeTxHash();
+        ),
+      ).rejects.toThrow(
+        Error(
+          `No voucher available for the requester ${requesterWallet.address}`,
+        ),
+      );
+    });
+
+    test('requires voucherHubAddress to be configured when useVoucher is true', async () => {
+      const noVoucherTestChain = TEST_CHAINS['custom-token-chain'];
+      const options = {
+        resultProxyURL: 'https://result-proxy.iex.ec',
+        smsURL: 'https://sms.iex.ec',
+      };
+      const { iexec: iexecRequester, wallet: requesterWallet } = getTestConfig(
+        noVoucherTestChain,
+      )({
+        options,
       });
+      const { iexec: iexecResourcesProvider, wallet: providerWallet } =
+        getTestConfig(noVoucherTestChain)({
+          options,
+        });
+
+      await setBalance(noVoucherTestChain)(requesterWallet.address, ONE_ETH);
+      await setBalance(noVoucherTestChain)(providerWallet.address, ONE_ETH);
+
+      const apporder = await deployAndGetApporder(iexecResourcesProvider, {
+        volume: 10,
+        appprice: 5,
+      });
+      const datasetorder = await deployAndGetDatasetorder(
+        iexecResourcesProvider,
+        {
+          volume: 7,
+          datasetprice: 1,
+        },
+      );
+      const workerpoolorder = await deployAndGetWorkerpoolorder(
+        iexecResourcesProvider,
+        { volume: 5, workerpoolprice: 1 },
+      );
+      const requestorder = await getMatchableRequestorder(iexecRequester, {
+        apporder,
+        datasetorder,
+        workerpoolorder,
+      });
+
+      await setNRlcBalance(noVoucherTestChain)(requesterWallet.address, 100);
+      await iexecRequester.account.deposit(100);
+      await expect(
+        iexecRequester.order.matchOrders(
+          {
+            apporder,
+            datasetorder,
+            workerpoolorder,
+            requestorder,
+          },
+          { useVoucher: true },
+        ),
+      ).rejects.toThrow(
+        new ConfigurationError(
+          `voucherHubAddress option not set and no default value for your chain ${noVoucherTestChain.chainId}`,
+        ),
+      );
+      // match orders without useVoucher should pass
+      const res = await iexecRequester.order.matchOrders(
+        {
+          apporder,
+          datasetorder,
+          workerpoolorder,
+          requestorder,
+        },
+        { useVoucher: false },
+      );
+      expect(res.txHash).toBeTxHash();
+      expect(res.volume).toBeInstanceOf(BN);
+      expect(res.volume.eq(new BN(5))).toBe(true);
+      expect(res.dealid).toBeTxHash();
+    });
+
+    test('should throw error for insufficient voucher allowance', async () => {
+      const { iexec: iexecRequester, wallet: requesterWallet } =
+        getTestConfig(iexecTestChain)();
+      const { iexec: iexecResourcesProvider } = getTestConfig(iexecTestChain)();
+
+      const apporder = await deployAndGetApporder(iexecResourcesProvider, {
+        volume: 10,
+        appprice: 5,
+      });
+      const datasetorder = await deployAndGetDatasetorder(
+        iexecResourcesProvider,
+        {
+          volume: 7,
+          datasetprice: 1,
+        },
+      );
+      const workerpoolorder = await deployAndGetWorkerpoolorder(
+        iexecResourcesProvider,
+        { volume: 5, workerpoolprice: 1 },
+      );
+      const requestorder = await getMatchableRequestorder(iexecRequester, {
+        apporder,
+        datasetorder,
+        workerpoolorder,
+      });
+      const voucherTypeId = await createVoucherType(iexecTestChain)({
+        description: 'test voucher type',
+        duration: 42,
+      });
+      await addVoucherEligibleAsset(iexecTestChain)(
+        datasetorder.dataset,
+        voucherTypeId,
+      );
+      await addVoucherEligibleAsset(iexecTestChain)(
+        workerpoolorder.workerpool,
+        voucherTypeId,
+      );
+      const voucherAddress = await createVoucher(iexecTestChain)({
+        owner: await requesterWallet.getAddress(),
+        voucherType: voucherTypeId,
+        value: 1000,
+      });
+      const allowance = await iexecRequester.account.checkAllowance(
+        requestorder.requester,
+        voucherAddress,
+      );
+      const { total, sponsored } =
+        await iexecRequester.order.estimateMatchOrders(
+          { apporder, datasetorder, workerpoolorder, requestorder },
+          { preflightCheck: true, useVoucher: true },
+        );
+
+      const requiredAmount = total.sub(sponsored);
+      const missingAmount = requiredAmount.sub(allowance);
+
+      await expect(
+        iexecRequester.order.matchOrders(
+          {
+            apporder,
+            datasetorder,
+            workerpoolorder,
+            requestorder,
+          },
+          { useVoucher: true },
+        ),
+      ).rejects.toThrow(
+        Error(
+          `Orders can't be matched. Please approve an additional ${missingAmount} for voucher usage.`,
+        ),
+      );
+    });
+
+    test('should match orders with voucher when user deposits to cover the missing amount', async () => {
+      const { iexec: iexecRequester, wallet: requesterWallet } =
+        getTestConfig(iexecTestChain)();
+      const { iexec: iexecResourcesProvider } = getTestConfig(iexecTestChain)();
+
+      const apporder = await deployAndGetApporder(iexecResourcesProvider, {
+        volume: 10,
+        appprice: 5,
+      });
+      const datasetorder = await deployAndGetDatasetorder(
+        iexecResourcesProvider,
+        {
+          volume: 7,
+          datasetprice: 1,
+        },
+      );
+      const workerpoolorder = await deployAndGetWorkerpoolorder(
+        iexecResourcesProvider,
+        { volume: 5, workerpoolprice: 1 },
+      );
+      const requestorder = await getMatchableRequestorder(iexecRequester, {
+        apporder,
+        datasetorder,
+        workerpoolorder,
+      });
+      const voucherTypeId = await createVoucherType(iexecTestChain)({
+        description: 'test voucher type',
+        duration: 42,
+      });
+      await addVoucherEligibleAsset(iexecTestChain)(
+        datasetorder.dataset,
+        voucherTypeId,
+      );
+      await addVoucherEligibleAsset(iexecTestChain)(
+        workerpoolorder.workerpool,
+        voucherTypeId,
+      );
+
+      const voucherAddress = await createVoucher(iexecTestChain)({
+        owner: await requesterWallet.getAddress(),
+        voucherType: voucherTypeId,
+        value: 1000,
+      });
+      await setNRlcBalance(iexecTestChain)(requesterWallet.address, 30);
+      await iexecRequester.account.deposit(30);
+      await iexecRequester.account.approve(25, voucherAddress);
+      const res = await iexecRequester.order.matchOrders(
+        {
+          apporder,
+          datasetorder,
+          workerpoolorder,
+          requestorder,
+        },
+        { useVoucher: true },
+      );
+      expect(res.txHash).toBeTxHash();
+      expect(res.volume).toBeInstanceOf(BN);
+      expect(res.volume.eq(new BN(5))).toBe(true);
+      expect(res.dealid).toBeTxHash();
     });
   });
 });

--- a/test/lib/unit/validator.test.js
+++ b/test/lib/unit/validator.test.js
@@ -875,6 +875,13 @@ describe('[tagSchema]', () => {
 });
 
 describe('[addressSchema]', () => {
+  test('undefined', async () => {
+    await expect(
+      addressSchema({
+        ethProvider: getDefaultProvider(mainnetHost),
+      }).validate(undefined),
+    ).resolves.toBe(undefined);
+  });
   test('address', async () => {
     await expect(
       addressSchema().validate('0x607F4C5BB672230e8672085532f7e901544a7375'),
@@ -901,15 +908,6 @@ describe('[addressSchema]', () => {
       ),
     );
   });
-  test('address undefined (throw)', async () => {
-    await expect(
-      addressSchema({ ethProvider: getDefaultProvider(mainnetHost) }).validate(
-        undefined,
-      ),
-    ).rejects.toThrow(
-      new ValidationError('undefined is not a valid ethereum address'),
-    );
-  });
   test('ens (resolve ENS with ethProvider)', async () => {
     await expect(
       addressSchema({ ethProvider: getDefaultProvider(mainnetHost) }).validate(
@@ -934,6 +932,13 @@ describe('[addressSchema]', () => {
 });
 
 describe('[addressOrAnySchema]', () => {
+  test('undefined', async () => {
+    await expect(
+      addressOrAnySchema({
+        ethProvider: getDefaultProvider(mainnetHost),
+      }).validate(undefined),
+    ).resolves.toBe(undefined);
+  });
   test('any', async () => {
     await expect(addressOrAnySchema().validate('any')).resolves.toBe('any');
   });
@@ -965,15 +970,6 @@ describe('[addressOrAnySchema]', () => {
       new ValidationError(
         '0x07F4C5BB672230e8672085532f7e901544a7375 is not a valid ethereum address',
       ),
-    );
-  });
-  test('address undefined (throw)', async () => {
-    await expect(
-      addressOrAnySchema({
-        ethProvider: getDefaultProvider(mainnetHost),
-      }).validate(undefined),
-    ).rejects.toThrow(
-      new ValidationError('undefined is not a valid ethereum address'),
     );
   });
   test('ens (resolve ENS with ethProvider)', async () => {


### PR DESCRIPTION
# Use authorized voucher

## Feature

Allow requester to use a voucher on which the requester is authorized instead of the requester's own voucher.

- added `voucherAddress` option to `matchOrders` and `estimateMatchOrders`
- added `--voucher-address` to cli commands `iexec app run` and `iexec order fill` 

## Misc

- chore: changed address `addressSchema` validator to accept `undefined` by default, previous behaviour is ensured by using `addressSchema().required()` (well that's a lot of touched files)
- chore: refactored some tests (fixed some bugs on the way promises non awaited)
- chore: refactored internal methods using too many positional args into named args 