### PR TITLE
feat: add support for arbitrum-mainnet

### DIFF
--- a/docs/interfaces/IExecConfigArgs.md
+++ b/docs/interfaces/IExecConfigArgs.md
@@ -19,6 +19,7 @@ A web3 Eth provider, a network name, a chain id or an ethers provider
 read-only provider examples:
 - `"mainnet"` or `1` or `"1"` for ethereum mainnet provider
 - `"bellecour"` or `134` or `"134"` for iExec sidechain
+- `"arbitrum-mainnet"` or `42161` or `"42161"` for arbitrum mainnet provider
 - `"http://localhost:8545"` for local chain
 - `new ethers.JsonRpcProvider("https://bellecour.iex.ec")` ethers provider connected to bellecour
 

--- a/src/cli/utils/templates.js
+++ b/src/cli/utils/templates.js
@@ -148,6 +148,7 @@ export const chains = {
   chains: {
     mainnet: {},
     bellecour: {},
+    'arbitrum-mainnet': {},
   },
 };
 

--- a/src/common/utils/config.js
+++ b/src/common/utils/config.js
@@ -1,6 +1,6 @@
-import { Network, EnsPlugin } from 'ethers';
-import { TEE_FRAMEWORKS } from './constant.js';
+import { EnsPlugin, Network } from 'ethers';
 import { address as voucherHubBellecourAddress } from '../generated/@iexec/voucher-contracts/deployments/bellecour/VoucherHubERC1967Proxy.js';
+import { TEE_FRAMEWORKS } from './constant.js';
 
 const networkConfigs = [
   {
@@ -72,6 +72,27 @@ const networkConfigs = [
     bridge: {}, // no bridge
     shouldRegisterNetwork: false,
     isExperimental: true,
+  },
+  {
+    id: 42161,
+    name: 'arbitrum-mainnet',
+    hub: '0x098bFCb1E50ebcA0BaA92C12eA0c3F045A1aD9f0',
+    host: 'https://arb1.arbitrum.io/rpc',
+    ensRegistry: undefined, // not supported
+    ensPublicResolver: undefined, // not supported
+    sms: {
+      [TEE_FRAMEWORKS.SCONE]: 'https://sms.arbitrum-mainnet.iex.ec',
+    },
+    resultProxy: undefined, // not exposed
+    ipfsGateway: 'https://ipfs-gateway.arbitrum-mainnet.iex.ec',
+    iexecGateway: 'https://api.market.arbitrum-mainnet.iex.ec',
+    compass: 'https://compass.arbitrum-mainnet.iex.ec',
+    pocoSubgraph:
+      'https://thegraph.arbitrum.iex.ec/api/subgraphs/id/B1comLe9SANBLrjdnoNTJSubbeC7cY7EoNu6zD82HeKy',
+    voucherHub: undefined, // no voucher
+    voucherSubgraph: undefined, // no voucher
+    bridge: {}, // no bridge
+    shouldRegisterNetwork: false,
   },
 ];
 

--- a/src/lib/IExecConfig.d.ts
+++ b/src/lib/IExecConfig.d.ts
@@ -19,6 +19,7 @@ export interface IExecConfigArgs {
    * read-only provider examples:
    * - `"mainnet"` or `1` or `"1"` for ethereum mainnet provider
    * - `"bellecour"` or `134` or `"134"` for iExec sidechain
+   * - `"arbitrum-mainnet"` or `42161` or `"42161"` for arbitrum mainnet provider
    * - `"http://localhost:8545"` for local chain
    * - `new ethers.JsonRpcProvider("https://bellecour.iex.ec")` ethers provider connected to bellecour
    *


### PR DESCRIPTION
Draft PR to prepare `arbitrum-mainnet` chain addition

TODO:
- [x] set arbitrum-mainnet PoCo address
- [x] set arbitrum-mainnet PoCo subgraph ID
- [x] wait for all services to be running on arbitrum-mainnet
  - [x] https://sms.arbitrum-mainnet.iex.ec
  - [x] https://ipfs-gateway.arbitrum-mainnet.iex.ec
  - [x] https://api.market.arbitrum-mainnet.iex.ec
  - [x] https://compass.arbitrum-mainnet.iex.ec
- [ ] rebuild `npm run build` and commit changes if necessary