### PR TITLE
fix: set TDX as default tag for all order creation

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -41,10 +41,6 @@ jobs:
     with:
       node-version: '20'
       upload-coverage: true
-    secrets:
-      infura-project-id: ${{ secrets.INFURA_PROJECT_ID }}
-      etherscan-api-key: ${{ secrets.ETHERSCAN_API_KEY }}
-      alchemy-api-key: ${{ secrets.ALCHEMY_API_KEY }}
 
   test-supported-node-versions:
     uses: ./.github/workflows/reusable-test.yml
@@ -55,10 +51,6 @@ jobs:
         node-version: ['22', '24']
     with:
       node-version: ${{ matrix.node-version }}
-    secrets:
-      infura-project-id: ${{ secrets.INFURA_PROJECT_ID }}
-      etherscan-api-key: ${{ secrets.ETHERSCAN_API_KEY }}
-      alchemy-api-key: ${{ secrets.ALCHEMY_API_KEY }}
 
   # sonar:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -1,5 +1,4 @@
 name: test SDK
-description: reusable test workflow for this project
 
 on:
   workflow_call:
@@ -12,13 +11,6 @@ on:
         description: 'Upload coverage data for later reuse'
         type: boolean
         default: false
-    secrets:
-      infura-project-id:
-        required: true
-      etherscan-api-key:
-        required: true
-      alchemy-api-key:
-        required: true
     outputs:
       coverage-artifact-id:
         description: 'Coverage artifact id (if `upload-coverage: true`)'
@@ -54,9 +46,6 @@ jobs:
         run: npm test
         env:
           USE_LOCAL_CLI: true
-          INFURA_PROJECT_ID: ${{ secrets.infura-project-id }}
-          ETHERSCAN_API_KEY: ${{ secrets.etherscan-api-key }}
-          ALCHEMY_API_KEY: ${{ secrets.alchemy-api-key }}
 
       - name: Stop e2e test stack
         if: always()

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Test
         run: npm test
         env:
+          USE_LOCAL_CLI: true
           INFURA_PROJECT_ID: ${{ secrets.infura-project-id }}
           ETHERSCAN_API_KEY: ${{ secrets.etherscan-api-key }}
           ALCHEMY_API_KEY: ${{ secrets.alchemy-api-key }}

--- a/CLI.md
+++ b/CLI.md
@@ -68,35 +68,17 @@ iexec wallet show # show your wallet
 iexec storage init # initialize your remote storage
 ```
 
-> _NB:_ iExec SDK CLI access the blockchain through [ethers](https://github.com/ethers-io/ethers.js/) to connect different backends ([Alchemy](https://alchemyapi.io/), [Etherscan](https://etherscan.io/), [INFURA](https://infura.io/)).
->
-> Default API keys for backend services are provided for convenience.
-> As these keys are shared across all users and are subject to rate limits, **you must use your own API keys** or better **your own node**.
+> _NB:_ iExec SDK CLI access the blockchain through RPC nodes
+> Default RPCs are provided for convenience.
+> As these RPC nodes are shared across all users and are subject to limitations, **you must use your own API keys** or better **your own node**.
 >
 > Get API keys for backend services:
 >
-> - [INFURA](https://infura.io/register) ([more details on Infura's blog](https://blog.infura.io/getting-started-with-infura-28e41844cc89/))
+> - [INFURA](https://app.infura.io/register)
 > - [Etherscan](https://etherscan.io/apis)
-> - [Alchemy](https://alchemyapi.io/signup)
+> - [Alchemy](https://www.alchemy.com)
 >
-> Once you created your access, you can add your API keys in the `chains.json` configuration file:
->
-> ```json
-> {
->    "default": ...,
->    "chains": { ... },
->    "providers": {
->      "infura": {
->        "projectId": "INFURA_PROJECT_ID",
->        "projectSecret": "INFURA_PROJECT_SECRET"
->       },
->     "etherscan": "ETHERSCAN_API_KEY",
->     "alchemy": "ALCHEMY_API_KEY"
->    }
-> }
-> ```
->
-> If you run your own node, you can add an `host` key in the `chains.json` configuration file to target your node:
+> You can add your RPC as `host` in the `chains.json` configuration file:
 >
 > ```json
 > {
@@ -104,7 +86,7 @@ iexec storage init # initialize your remote storage
 >    "chains": {
 >       ...
 >       "arbitrum-mainnet": {
->         "host": "http://localhost:8545"
+>         "host": "https://<your_node_url>",
 >       }
 >    }
 > }

--- a/README.md
+++ b/README.md
@@ -73,12 +73,6 @@ Run tests when the stack is up
 npm run test
 ```
 
-> Some tests relies on RPC API providers, to have them running smoothly you can provide the following envs
->
-> - ALCHEMY_API_KEY (obtained from <https://alchemy.com>)
-> - ETHERSCAN_API_KEY (obtained from <https://etherscan.io>)
-> - INFURA_PROJECT_ID (obtained from <https://infura.io>)
-
 ## Changelog
 
 Find changes in the [CHANGELOG](./CHANGELOG.md)

--- a/cli_template.md
+++ b/cli_template.md
@@ -68,35 +68,17 @@ iexec wallet show # show your wallet
 iexec storage init # initialize your remote storage
 ```
 
-> _NB:_ iExec SDK CLI access the blockchain through [ethers](https://github.com/ethers-io/ethers.js/) to connect different backends ([Alchemy](https://alchemyapi.io/), [Etherscan](https://etherscan.io/), [INFURA](https://infura.io/)).
->
-> Default API keys for backend services are provided for convenience.
-> As these keys are shared across all users and are subject to rate limits, **you must use your own API keys** or better **your own node**.
+> _NB:_ iExec SDK CLI access the blockchain through RPC nodes
+> Default RPCs are provided for convenience.
+> As these RPC nodes are shared across all users and are subject to limitations, **you must use your own API keys** or better **your own node**.
 >
 > Get API keys for backend services:
 >
-> - [INFURA](https://infura.io/register) ([more details on Infura's blog](https://blog.infura.io/getting-started-with-infura-28e41844cc89/))
+> - [INFURA](https://app.infura.io/register)
 > - [Etherscan](https://etherscan.io/apis)
-> - [Alchemy](https://alchemyapi.io/signup)
+> - [Alchemy](https://www.alchemy.com)
 >
-> Once you created your access, you can add your API keys in the `chains.json` configuration file:
->
-> ```json
-> {
->    "default": ...,
->    "chains": { ... },
->    "providers": {
->      "infura": {
->        "projectId": "INFURA_PROJECT_ID",
->        "projectSecret": "INFURA_PROJECT_SECRET"
->       },
->     "etherscan": "ETHERSCAN_API_KEY",
->     "alchemy": "ALCHEMY_API_KEY"
->    }
-> }
-> ```
->
-> If you run your own node, you can add an `host` key in the `chains.json` configuration file to target your node:
+> You can add your RPC as `host` in the `chains.json` configuration file:
 >
 > ```json
 > {
@@ -104,7 +86,7 @@ iexec storage init # initialize your remote storage
 >    "chains": {
 >       ...
 >       "arbitrum-mainnet": {
->         "host": "http://localhost:8545"
+>         "host": "https://<your_node_url>",
 >       }
 >    }
 > }

--- a/src/cli/utils/templates.js
+++ b/src/cli/utils/templates.js
@@ -1,4 +1,7 @@
-import { IEXEC_REQUEST_PARAMS } from '../../common/utils/constant.js';
+import {
+  IEXEC_REQUEST_PARAMS,
+  TDX_DEFAULT_TAG,
+} from '../../common/utils/constant.js';
 
 export const main = {
   description:
@@ -25,7 +28,7 @@ export const buyConf = {
   params: {
     [IEXEC_REQUEST_PARAMS.IEXEC_ARGS]: '',
   },
-  tag: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  tag: TDX_DEFAULT_TAG,
   trust: '0',
   callback: '0x0000000000000000000000000000000000000000',
 };
@@ -58,7 +61,7 @@ export const order = {
     app: '0x0000000000000000000000000000000000000000',
     appprice: '0',
     volume: '1000000',
-    tag: [],
+    tag: ['tee', 'tdx'],
     datasetrestrict: '0x0000000000000000000000000000000000000000', // todo remove from default
     workerpoolrestrict: '0x0000000000000000000000000000000000000000', // todo remove from default
     requesterrestrict: '0x0000000000000000000000000000000000000000', // todo remove from default
@@ -67,7 +70,7 @@ export const order = {
     dataset: '0x0000000000000000000000000000000000000000',
     datasetprice: '0',
     volume: '1000000',
-    tag: [], // todo remove from default
+    tag: ['tee', 'tdx'], // todo remove from default
     apprestrict: '0x0000000000000000000000000000000000000000', // todo remove from default
     workerpoolrestrict: '0x0000000000000000000000000000000000000000', // todo remove from default
     requesterrestrict: '0x0000000000000000000000000000000000000000', // todo remove from default
@@ -78,7 +81,7 @@ export const order = {
     volume: '1',
     category: '0',
     trust: '0',
-    tag: [], // todo remove from default
+    tag: ['tee', 'tdx'], // todo remove from default
     apprestrict: '0x0000000000000000000000000000000000000000', // todo remove from default
     datasetrestrict: '0x0000000000000000000000000000000000000000', // todo remove from default
     requesterrestrict: '0x0000000000000000000000000000000000000000', // todo remove from default
@@ -93,7 +96,7 @@ export const order = {
     volume: '1',
     category: '0',
     trust: '0', // todo remove from default
-    tag: [], // todo remove from default
+    tag: ['tee', 'tdx'], // todo remove from default
     beneficiary: '0x0000000000000000000000000000000000000000', // todo remove from default
     callback: '0x0000000000000000000000000000000000000000', // todo remove from default
     params: {

--- a/src/common/market/order.js
+++ b/src/common/market/order.js
@@ -27,8 +27,9 @@ import {
 import { hashEIP712 } from '../utils/sig-utils.js';
 import {
   NULL_BYTES,
-  NULL_BYTES32,
   NULL_ADDRESS,
+  NULL_BYTES32,
+  TDX_DEFAULT_TAG,
   APP_ORDER,
   DATASET_ORDER,
   WORKERPOOL_ORDER,
@@ -333,7 +334,15 @@ const signOrder = async (
 export const signApporder = async (
   contracts = throwIfMissing(),
   apporder = throwIfMissing(),
-) => signOrder(contracts, APP_ORDER, await apporderSchema().validate(apporder));
+) =>
+  signOrder(
+    contracts,
+    APP_ORDER,
+    await apporderSchema().validate({
+      ...apporder,
+      tag: sumTags([await tagSchema().validate(apporder.tag), TDX_DEFAULT_TAG]),
+    }),
+  );
 
 export const signDatasetorder = async (
   contracts = throwIfMissing(),
@@ -342,7 +351,16 @@ export const signDatasetorder = async (
   signOrder(
     contracts,
     DATASET_ORDER,
-    await datasetorderSchema().validate(datasetorder),
+    await datasetorderSchema().validate({
+      ...datasetorder,
+      tag: sumTags([
+        await tagSchema({
+          allowAgnosticTee: true,
+          ignoreLegacyTeeFramework: true,
+        }).validate(datasetorder.tag),
+        TDX_DEFAULT_TAG,
+      ]),
+    }),
   );
 
 export const signWorkerpoolorder = async (
@@ -352,7 +370,13 @@ export const signWorkerpoolorder = async (
   signOrder(
     contracts,
     WORKERPOOL_ORDER,
-    await workerpoolorderSchema().validate(workerpoolorder),
+    await workerpoolorderSchema().validate({
+      ...workerpoolorder,
+      tag: sumTags([
+        await tagSchema().validate(workerpoolorder.tag),
+        TDX_DEFAULT_TAG,
+      ]),
+    }),
   );
 
 export const signRequestorder = async (
@@ -362,7 +386,13 @@ export const signRequestorder = async (
   signOrder(
     contracts,
     REQUEST_ORDER,
-    await requestorderSchema().validate(requestorder),
+    await requestorderSchema().validate({
+      ...requestorder,
+      tag: sumTags([
+        await tagSchema().validate(requestorder.tag),
+        TDX_DEFAULT_TAG,
+      ]),
+    }),
   );
 
 const cancelOrder = async (
@@ -462,6 +492,28 @@ const getMatchableVolume = async (
         signedWorkerpoolorderSchema().validate(workerpoolOrder),
         signedRequestorderSchema().validate(requestOrder),
       ]);
+
+    // check resulting tag
+    const resultingTag = await tagSchema()
+      .validate(
+        sumTags([
+          vAppOrder.tag,
+          stripTeeFrameworkFromTag(vDatasetOrder.tag),
+          vRequestOrder.tag,
+        ]),
+      )
+      .catch((e) => {
+        throw new Error(
+          `Matching order would produce an invalid deal tag. ${e.message}`,
+        );
+      });
+    const isTee = checkActiveBitInTag(resultingTag, TAG_MAP.tee);
+    const isTdx = checkActiveBitInTag(resultingTag, TAG_MAP.tdx);
+    if (!isTee || !isTdx) {
+      throw new Error(
+        'Resulting deal tag must have both [tee] and [tdx] tags active. Matching orders have incompatible tags.',
+      );
+    }
 
     // deployment checks
     const checkAppDeployedAsync = async () => {
@@ -793,21 +845,6 @@ export const matchOrders = async ({
           .validate(requestorder),
       ]);
 
-    // check resulting tag
-    await tagSchema()
-      .validate(
-        sumTags([
-          vAppOrder.tag,
-          stripTeeFrameworkFromTag(vDatasetOrder.tag),
-          vRequestOrder.tag,
-        ]),
-      )
-      .catch((e) => {
-        throw new Error(
-          `Matching order would produce an invalid deal tag. ${e.message}`,
-        );
-      });
-
     // check matchability
     const matchableVolume = await getMatchableVolume(
       contracts,
@@ -892,7 +929,9 @@ export const createApporder = async ({
   app: await addressSchema().required().label('app').validate(app),
   appprice: await nRlcAmountSchema().validate(appprice),
   volume: await uint256Schema().validate(volume),
-  tag: await tagSchema().validate(tag),
+  tag: await tagSchema().validate(
+    sumTags([await tagSchema().validate(tag), TDX_DEFAULT_TAG]),
+  ),
   datasetrestrict: await addressSchema().validate(datasetrestrict),
   workerpoolrestrict: await addressSchema().validate(workerpoolrestrict),
   requesterrestrict: await addressSchema().validate(requesterrestrict),
@@ -911,9 +950,16 @@ export const createDatasetorder = async ({
   datasetprice: await nRlcAmountSchema().validate(datasetprice),
   volume: await uint256Schema().validate(volume),
   tag: await tagSchema({
-    allowAgnosticTee: true,
     ignoreLegacyTeeFramework: true,
-  }).validate(tag),
+  }).validate(
+    sumTags([
+      await tagSchema({
+        allowAgnosticTee: true,
+        ignoreLegacyTeeFramework: true,
+      }).validate(tag),
+      TDX_DEFAULT_TAG,
+    ]),
+  ),
   apprestrict: await addressSchema().validate(apprestrict),
   workerpoolrestrict: await addressSchema().validate(workerpoolrestrict),
   requesterrestrict: await addressSchema().validate(requesterrestrict),
@@ -935,7 +981,9 @@ export const createWorkerpoolorder = async ({
   volume: await uint256Schema().validate(volume),
   category: await uint256Schema().validate(category),
   trust: await uint256Schema().validate(trust),
-  tag: await tagSchema().validate(tag),
+  tag: await tagSchema().validate(
+    sumTags([await tagSchema().validate(tag), TDX_DEFAULT_TAG]),
+  ),
   apprestrict: await addressSchema().validate(apprestrict),
   datasetrestrict: await addressSchema().validate(datasetrestrict),
   requesterrestrict: await addressSchema().validate(requesterrestrict),
@@ -961,7 +1009,12 @@ export const createRequestorder = async (
   } = {},
 ) => {
   const requesterOrUser = requester || (await getAddress(contracts));
-  const vTag = await tagSchema({ allowAgnosticTee: true }).validate(tag);
+  const vTag = await tagSchema().validate(
+    sumTags([
+      await tagSchema({ allowAgnosticTee: true }).validate(tag),
+      TDX_DEFAULT_TAG,
+    ]),
+  );
   return {
     app: await addressSchema().required().label('app').validate(app),
     appmaxprice: await nRlcAmountSchema().validate(appmaxprice),

--- a/src/common/utils/constant.js
+++ b/src/common/utils/constant.js
@@ -30,6 +30,10 @@ export const TEE_FRAMEWORKS = {
   TDX: 'tdx',
 };
 
+// TDX default tag: bit 0 (tee) + bit 3 (tdx) = 0x9
+export const TDX_DEFAULT_TAG =
+  '0x0000000000000000000000000000000000000000000000000000000000000009';
+
 export const STORAGE_PROVIDERS = {
   DROPBOX: 'dropbox',
   IPFS: 'ipfs',

--- a/test/cli/cli-iexec-app.test.js
+++ b/test/cli/cli-iexec-app.test.js
@@ -20,6 +20,7 @@ import {
 } from './cli-test-utils.js';
 import '../jest-setup.js';
 import { encodeTag } from '../../src/lib/utils.js';
+import { TDX_DEFAULT_TAG } from '../../src/common/utils/constant.js';
 
 const testChain = TEST_CHAINS['arbitrum-sepolia-fork'];
 
@@ -202,7 +203,7 @@ describe('iexec app', () => {
       expect(resDeal.deal.beneficiary).toBe(userWallet.address);
       expect(resDeal.deal.botFirst).toBe('0');
       expect(resDeal.deal.botSize).toBe('1');
-      expect(resDeal.deal.tag).toBe(NULL_BYTES32);
+      expect(resDeal.deal.tag).toBe(TDX_DEFAULT_TAG);
       expect(resDeal.deal.trust).toBe('1');
       expect(Object.keys(resDeal.deal.tasks).length).toBe(1);
       expect(resDeal.deal.tasks['0']).toBeDefined();
@@ -241,7 +242,7 @@ describe('iexec app', () => {
       expect(resDeal.deal.beneficiary).toBe(userWallet.address);
       expect(resDeal.deal.botFirst).toBe('0');
       expect(resDeal.deal.botSize).toBe('1');
-      expect(resDeal.deal.tag).toBe(NULL_BYTES32);
+      expect(resDeal.deal.tag).toBe(TDX_DEFAULT_TAG);
       expect(resDeal.deal.trust).toBe('1');
       expect(Object.keys(resDeal.deal.tasks).length).toBe(1);
       expect(resDeal.deal.tasks['0']).toBeDefined();
@@ -400,7 +401,7 @@ describe('iexec app', () => {
         app: address,
         appprice: 0,
         volume: 1000000,
-        tag: NULL_BYTES32,
+        tag: TDX_DEFAULT_TAG,
         datasetrestrict: NULL_ADDRESS,
         workerpoolrestrict: NULL_ADDRESS,
         requesterrestrict: NULL_ADDRESS,
@@ -422,7 +423,7 @@ describe('iexec app', () => {
         app: userFirstDeployedAppAddress,
         appprice: 100000000,
         volume: 100,
-        tag: '0x0000000000000000000000000000000000000000000000000000000000000000',
+        tag: TDX_DEFAULT_TAG,
         datasetrestrict: NULL_ADDRESS,
         workerpoolrestrict: NULL_ADDRESS,
         requesterrestrict: NULL_ADDRESS,

--- a/test/cli/cli-iexec-dataset.test.js
+++ b/test/cli/cli-iexec-dataset.test.js
@@ -1,7 +1,6 @@
 import { describe, test, expect } from '@jest/globals';
 import {
   NULL_ADDRESS,
-  NULL_BYTES32,
   TEST_CHAINS,
   execAsync,
   getRandomAddress,
@@ -17,12 +16,15 @@ import {
   checkExists,
 } from './cli-test-utils.js';
 import '../jest-setup.js';
+import { TDX_DEFAULT_TAG } from '../../src/common/utils/constant.js';
+import { sumTags } from '../../src/lib/utils.js';
 
 const testChain = TEST_CHAINS['arbitrum-sepolia-fork'];
 
 describe('iexec dataset', () => {
   let userWallet;
   let userFirstDeployedDatasetAddress;
+  let userDatasetMissingSecret;
 
   beforeAll(async () => {
     await globalSetup('cli-iexec-dataset');
@@ -33,7 +35,15 @@ describe('iexec dataset', () => {
     await execAsync(`${iexecPath} dataset init`);
     await setDatasetUniqueName();
     const deployed = await runIExecCliRaw(`${iexecPath} dataset deploy`);
+    await execAsync(
+      `echo "foo" > secret.txt && ${iexecPath} dataset push-secret --secret-path secret.txt`,
+    );
     userFirstDeployedDatasetAddress = deployed.address;
+    await setDatasetUniqueName();
+    const deployedMissingSecret = await runIExecCliRaw(
+      `${iexecPath} dataset deploy`,
+    );
+    userDatasetMissingSecret = deployedMissingSecret.address;
   });
 
   afterAll(async () => {
@@ -271,6 +281,9 @@ describe('iexec dataset', () => {
     test('from deployed', async () => {
       await setDatasetUniqueName();
       const { address } = await runIExecCliRaw(`${iexecPath} dataset deploy`);
+      await execAsync(
+        `echo "foo" > secret.txt && ${iexecPath} dataset push-secret --secret-path secret.txt`,
+      );
       const res = await runIExecCliRaw(`${iexecPath} dataset publish --force`);
       expect(res.ok).toBe(true);
       expect(res.orderHash).toBeDefined();
@@ -283,7 +296,7 @@ describe('iexec dataset', () => {
         dataset: address,
         datasetprice: 0,
         volume: 1000000,
-        tag: NULL_BYTES32,
+        tag: TDX_DEFAULT_TAG,
         apprestrict: NULL_ADDRESS,
         workerpoolrestrict: NULL_ADDRESS,
         requesterrestrict: NULL_ADDRESS,
@@ -296,13 +309,13 @@ describe('iexec dataset', () => {
       const appAddress = getRandomAddress();
       await expect(
         execAsync(
-          `${iexecPath} dataset publish ${userFirstDeployedDatasetAddress} --price 0.1 RLC --volume 100 --tag tee,tdx --app-restrict ${appAddress} --force`,
+          `${iexecPath} dataset publish ${userDatasetMissingSecret} --price 0.1 RLC --volume 100 --tag 0x1000000000000000000000000000000000000000000000000000000000000000 --app-restrict ${appAddress} --force`,
         ),
       ).rejects.toThrow(
-        `Dataset encryption key is not set for dataset ${userFirstDeployedDatasetAddress} in the SMS. Dataset decryption will fail.`,
+        `Dataset encryption key is not set for dataset ${userDatasetMissingSecret} in the SMS. Dataset decryption will fail.`,
       );
       const res = await runIExecCliRaw(
-        `${iexecPath} dataset publish ${userFirstDeployedDatasetAddress} --price 0.1 RLC --volume 100 --app-restrict ${appAddress} --force`,
+        `${iexecPath} dataset publish ${userFirstDeployedDatasetAddress} --price 0.1 RLC --volume 100 --tag 0x1000000000000000000000000000000000000000000000000000000000000000 --app-restrict ${appAddress} --force`,
       );
       expect(res.ok).toBe(true);
       expect(res.orderHash).toBeDefined();
@@ -315,7 +328,10 @@ describe('iexec dataset', () => {
         dataset: userFirstDeployedDatasetAddress,
         datasetprice: 100000000,
         volume: 100,
-        tag: '0x0000000000000000000000000000000000000000000000000000000000000000',
+        tag: sumTags([
+          '0x1000000000000000000000000000000000000000000000000000000000000000',
+          TDX_DEFAULT_TAG,
+        ]),
         apprestrict: appAddress,
         workerpoolrestrict: NULL_ADDRESS,
         requesterrestrict: NULL_ADDRESS,
@@ -329,6 +345,9 @@ describe('iexec dataset', () => {
     test('latest from deployed', async () => {
       await setDatasetUniqueName();
       await runIExecCliRaw(`${iexecPath} dataset deploy`);
+      await execAsync(
+        `echo "foo" > secret.txt && ${iexecPath} dataset push-secret --secret-path secret.txt`,
+      );
       await runIExecCliRaw(`${iexecPath} dataset publish --force`);
       const { orderHash: lastOrderHash } = await runIExecCliRaw(
         `${iexecPath} dataset publish --force`,

--- a/test/cli/cli-iexec-deal.test.js
+++ b/test/cli/cli-iexec-deal.test.js
@@ -43,6 +43,9 @@ describe('iexec deal', () => {
     await execAsync(`${iexecPath} workerpool init`);
     userApp = await runIExecCliRaw(`${iexecPath} app deploy`);
     userDataset = await runIExecCliRaw(`${iexecPath} dataset deploy`);
+    await execAsync(
+      `echo 'foo' > secret.txt && ${iexecPath} dataset push-secret ${userDataset.address} --secret-path secret.txt`,
+    );
     userWorkerpool = await runIExecCliRaw(`${iexecPath} workerpool deploy`);
     dealid = await runIExecCliRaw(
       `${iexecPath} app run ${userApp.address} --workerpool ${userWorkerpool.address} --dataset ${userDataset.address} --category ${noDurationCatid} --force`,

--- a/test/cli/cli-iexec-order.test.js
+++ b/test/cli/cli-iexec-order.test.js
@@ -9,6 +9,7 @@ import {
   globalTeardown,
   iexecPath,
   setChain,
+  setDatasetUniqueName,
   setRandomWallet,
 } from './cli-test-utils.js';
 import '../jest-setup.js';
@@ -19,6 +20,7 @@ describe('iexec order', () => {
   let userWallet;
   let userApp;
   let userDataset;
+  let userDatasetMissingSecret;
   let userWorkerpool;
 
   beforeAll(async () => {
@@ -33,8 +35,16 @@ describe('iexec order', () => {
     userApp = await execAsync(`${iexecPath} app deploy --raw`).then(
       (res) => JSON.parse(res).address,
     );
+    await setDatasetUniqueName();
+    userDatasetMissingSecret = await execAsync(
+      `${iexecPath} dataset deploy --raw`,
+    ).then((res) => JSON.parse(res).address);
+    await setDatasetUniqueName();
     userDataset = await execAsync(`${iexecPath} dataset deploy --raw`).then(
       (res) => JSON.parse(res).address,
+    );
+    await execAsync(
+      `echo "foo" > secret.txt && ${iexecPath} dataset push-secret ${userDataset} --secret-path secret.txt`,
     );
     userWorkerpool = await execAsync(
       `${iexecPath} workerpool deploy --raw`,
@@ -129,22 +139,26 @@ describe('iexec order', () => {
     expect(res.requestorder.app).toBeDefined();
 
     await editRequestorder({
+      dataset: userDatasetMissingSecret,
       tag: ['tee', 'tdx'],
     });
     await editWorkerpoolorder({
       tag: ['tee'],
     });
     await editApporder({ tag: ['tdx'] });
-    await editDatasetorder({ tag: ['tee', 'tdx'] });
+    await editDatasetorder({
+      dataset: userDatasetMissingSecret,
+      tag: ['tee', 'tdx'],
+    });
     const failRes = await execAsync(`${iexecPath} order sign --raw`).then(
       JSON.parse,
     );
     expect(failRes.ok).toBe(false);
     expect(failRes.fail).toStrictEqual([
       "apporder: 'tdx' tag must be used with 'tee' tag",
-      `datasetorder: Dataset requirements check failed: Dataset encryption key is not set for dataset ${userDataset} in the SMS. Dataset decryption will fail. (If you consider this is not an issue, use --skip-preflight-check to skip preflight requirement check)`,
+      `datasetorder: Dataset requirements check failed: Dataset encryption key is not set for dataset ${userDatasetMissingSecret} in the SMS. Dataset decryption will fail. (If you consider this is not an issue, use --skip-preflight-check to skip preflight requirement check)`,
       "workerpoolorder: 'tee' tag must be used with a tee framework ('tdx')",
-      `requestorder: Request requirements check failed: Dataset encryption key is not set for dataset ${userDataset} in the SMS. Dataset decryption will fail. (If you consider this is not an issue, use --skip-preflight-check to skip preflight requirement check)`,
+      `requestorder: Request requirements check failed: Dataset encryption key is not set for dataset ${userDatasetMissingSecret} in the SMS. Dataset decryption will fail. (If you consider this is not an issue, use --skip-preflight-check to skip preflight requirement check)`,
     ]);
   });
 

--- a/test/cli/cli-iexec-task.test.js
+++ b/test/cli/cli-iexec-task.test.js
@@ -42,6 +42,9 @@ describe('iexec task', () => {
     await execAsync(`${iexecPath} workerpool init`);
     userApp = await runIExecCliRaw(`${iexecPath} app deploy`);
     userDataset = await runIExecCliRaw(`${iexecPath} dataset deploy`);
+    await execAsync(
+      `echo 'foo' > secret.txt && ${iexecPath} dataset push-secret ${userDataset.address} --secret-path secret.txt`,
+    );
     userWorkerpool = await runIExecCliRaw(`${iexecPath} workerpool deploy`);
   });
 

--- a/test/cli/cli-iexec-workerpool.test.js
+++ b/test/cli/cli-iexec-workerpool.test.js
@@ -2,7 +2,6 @@ import { describe, test, expect } from '@jest/globals';
 import {
   TEST_CHAINS,
   NULL_ADDRESS,
-  NULL_BYTES32,
   execAsync,
   getRandomAddress,
 } from '../test-utils.js';
@@ -17,6 +16,7 @@ import {
 } from './cli-test-utils.js';
 import '../jest-setup.js';
 import { encodeTag } from '../../src/lib/utils.js';
+import { TDX_DEFAULT_TAG } from '../../src/common/utils/constant.js';
 
 const testChain = TEST_CHAINS['arbitrum-sepolia-fork'];
 
@@ -152,7 +152,7 @@ describe('iexec workerpool', () => {
         workerpool: address,
         workerpoolprice: 0,
         volume: 1,
-        tag: NULL_BYTES32,
+        tag: TDX_DEFAULT_TAG,
         trust: 0,
         category: 0,
         apprestrict: NULL_ADDRESS,

--- a/test/cli/cli-test-utils.js
+++ b/test/cli/cli-test-utils.js
@@ -7,7 +7,10 @@ import { execAsync, getId, setBalance } from '../test-utils.js';
 const IEXEC_JSON = 'iexec.json';
 const CHAIN_JSON = 'chain.json';
 
-export const iexecPath = 'iexec';
+export const iexecPath =
+  process.env.USE_LOCAL_CLI === 'true'
+    ? 'iexec' // use installed iexec cli
+    : '../../../src/cli/cmd/iexec.js';
 
 export const globalSetup = async (testid = 'shared') => {
   const testDir = `test/tests-working-dir/${testid}`;

--- a/test/cli/cli-test-utils.js
+++ b/test/cli/cli-test-utils.js
@@ -151,8 +151,9 @@ export const editApporder = async ({ tag }) =>
     tag,
   });
 
-export const editDatasetorder = async ({ tag }) =>
+export const editDatasetorder = async ({ dataset, tag }) =>
   editOrder('datasetorder')({
+    dataset,
     tag,
   });
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   arbitrum-sepolia-fork:
+    platform: linux/amd64
     restart: 'no'
     image: ghcr.io/foundry-rs/foundry:v1.0.0
     entrypoint: anvil
@@ -17,6 +18,7 @@ services:
       start_period: 30s
 
   unknown-chain-fork:
+    platform: linux/amd64
     restart: 'no'
     image: ghcr.io/foundry-rs/foundry:v1.0.0
     entrypoint: anvil
@@ -34,6 +36,7 @@ services:
       start_period: 30s
 
   service-internal-error:
+    platform: linux/amd64
     image: nginx:alpine
     volumes:
       - $PWD/mock/server/http500.nginx.conf:/etc/nginx/conf.d/default.conf:ro
@@ -43,6 +46,7 @@ services:
       - 5500:80
 
   sms-arbitrum-sepolia:
+    platform: linux/amd64
     image: iexechub/iexec-sms:8.7.0
     restart: unless-stopped
     environment:
@@ -63,6 +67,7 @@ services:
       arbitrum-sepolia-fork:
         condition: service_healthy
   ipfs:
+    platform: linux/amd64
     restart: unless-stopped
     image: ipfs/go-ipfs:v0.9.1
     expose:
@@ -79,6 +84,7 @@ services:
       start_period: 30s
 
   market-mongo:
+    platform: linux/amd64
     image: mongo:6.0.3
     restart: unless-stopped
     expose:
@@ -87,6 +93,7 @@ services:
       - 27017:27017
 
   market-redis:
+    platform: linux/amd64
     image: redis:7.0.7-alpine
     restart: unless-stopped
     command: redis-server --appendonly yes
@@ -102,6 +109,7 @@ services:
       start_period: 30s
 
   market-watcher-arbitrum-sepolia:
+    platform: linux/amd64
     image: iexechub/iexec-market-watcher:7.0.1
     restart: unless-stopped
     environment:
@@ -122,6 +130,7 @@ services:
         condition: service_started
 
   market-api-arbitrum-sepolia:
+    platform: linux/amd64
     image: iexechub/iexec-market-api:7.1.2
     restart: unless-stopped
     ports:
@@ -147,6 +156,7 @@ services:
         condition: service_started
 
   compass-arbitrum-sepolia:
+    platform: linux/amd64
     image: iexechub/compass:v0.1.1
     restart: unless-stopped
     environment:
@@ -159,6 +169,7 @@ services:
       test: nc -w 1 0.0.0.0 3000
 
   stack-ready:
+    platform: linux/amd64
     image: bash
     command:
       - echo "all services ready"

--- a/test/lib/e2e/IExecOrderModule.test.js
+++ b/test/lib/e2e/IExecOrderModule.test.js
@@ -25,7 +25,12 @@ import {
 } from '../../test-utils.js';
 import '../../jest-setup.js';
 import { errors } from '../../../src/lib/index.js';
-import { DATASET_INFINITE_VOLUME, encodeTag } from '../../../src/lib/utils.js';
+import {
+  DATASET_INFINITE_VOLUME,
+  encodeTag,
+  sumTags,
+} from '../../../src/lib/utils.js';
+import { TDX_DEFAULT_TAG } from '../../../src/common/utils/constant.js';
 
 const { MarketCallError } = errors;
 
@@ -50,6 +55,7 @@ describe('order', () => {
           .map(async () => {
             const { iexec: iexecDataOwner } = await getTestConfig(testChain)();
             const { address } = await deployRandomDataset(iexecDataOwner);
+            await iexecDataOwner.dataset.pushDatasetSecret(address, 'foo');
             const datasetBulkOrder = await iexecDataOwner.order
               .createDatasetorder({
                 dataset: address,
@@ -89,7 +95,7 @@ describe('order', () => {
           appprice: '0',
           datasetrestrict: '0x0000000000000000000000000000000000000000',
           requesterrestrict: '0x0000000000000000000000000000000000000000',
-          tag: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          tag: TDX_DEFAULT_TAG,
           volume: '1',
           workerpoolrestrict: '0x0000000000000000000000000000000000000000',
         });
@@ -134,7 +140,7 @@ describe('order', () => {
           dataset,
           datasetprice: '0',
           requesterrestrict: '0x0000000000000000000000000000000000000000',
-          tag: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          tag: TDX_DEFAULT_TAG,
           volume: '1',
           workerpoolrestrict: '0x0000000000000000000000000000000000000000',
         });
@@ -152,7 +158,7 @@ describe('order', () => {
           apprestrict,
           workerpoolrestrict,
           requesterrestrict,
-          tag: ['tee'],
+          tag: '0x1000000000000000000000000000000000000000000000000000000000000000',
           volume: 100,
         });
         expect(order).toEqual({
@@ -160,7 +166,10 @@ describe('order', () => {
           datasetprice: '1000000000',
           apprestrict,
           requesterrestrict,
-          tag: '0x0000000000000000000000000000000000000000000000000000000000000001',
+          tag: sumTags([
+            '0x1000000000000000000000000000000000000000000000000000000000000000',
+            TDX_DEFAULT_TAG,
+          ]), // tee tdx is added by default
           volume: '100',
           workerpoolrestrict,
         });
@@ -180,7 +189,7 @@ describe('order', () => {
           category: '5',
           datasetrestrict: '0x0000000000000000000000000000000000000000',
           requesterrestrict: '0x0000000000000000000000000000000000000000',
-          tag: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          tag: TDX_DEFAULT_TAG,
           trust: '0',
           volume: '1',
           workerpool,
@@ -201,7 +210,7 @@ describe('order', () => {
           apprestrict,
           datasetrestrict,
           requesterrestrict,
-          tag: ['tee', 'tdx'],
+          tag: '0x1000000000000000000000000000000000000000000000000000000000000000',
           trust: '10',
           volume: '100',
         });
@@ -210,7 +219,10 @@ describe('order', () => {
           category: '5',
           datasetrestrict,
           requesterrestrict,
-          tag: encodeTag(['tee', 'tdx']),
+          tag: sumTags([
+            '0x1000000000000000000000000000000000000000000000000000000000000000',
+            TDX_DEFAULT_TAG,
+          ]), // tee tdx is added by default
           trust: '10',
           volume: '100',
           workerpool,
@@ -239,7 +251,7 @@ describe('order', () => {
             iexec_result_storage_provider: 'ipfs',
           },
           requester: wallet.address,
-          tag: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          tag: TDX_DEFAULT_TAG,
           trust: '0',
           volume: '1',
           workerpool: '0x0000000000000000000000000000000000000000',
@@ -266,7 +278,7 @@ describe('order', () => {
             iexec_result_storage_provider: 'dropbox',
             iexec_result_encryption: true,
           },
-          tag: ['tee', 'tdx'],
+          tag: '0x1000000000000000000000000000000000000000000000000000000000000000',
           trust: '100',
           volume: '5',
         });
@@ -283,7 +295,10 @@ describe('order', () => {
             iexec_result_encryption: true,
           },
           requester: wallet.address,
-          tag: encodeTag(['tee', 'tdx']),
+          tag: sumTags([
+            '0x1000000000000000000000000000000000000000000000000000000000000000',
+            TDX_DEFAULT_TAG,
+          ]), // tee tdx is added by default
           trust: '100',
           volume: '5',
           workerpool,
@@ -531,36 +546,12 @@ describe('order', () => {
           await getTestConfig(testChain)();
         const { iexec: iexecDatasetConsumer } =
           await getTestConfig(testChain)();
-        const { address: dataset } =
-          await deployRandomDataset(iexecDatasetProvider);
-
-        // non tee pass
-        await expect(
-          iexecDatasetConsumer.order
-            .createRequestorder({
-              app: getRandomAddress(),
-              category: 5,
-              dataset,
-            })
-            .then(iexecDatasetConsumer.order.signRequestorder),
-        ).resolves.toBeDefined();
-
-        // tee fail without secret
-        await expect(
-          iexecDatasetConsumer.order
-            .createRequestorder({
-              app: getRandomAddress(),
-              category: 5,
-              dataset,
-              tag: ['tee', 'tdx'],
-            })
-            .then(iexecDatasetConsumer.order.signRequestorder),
-        ).rejects.toThrow(
-          new Error(
-            `Dataset encryption key is not set for dataset ${dataset} in the SMS. Dataset decryption will fail.`,
-          ),
+        const { address: dataset } = await deployRandomDataset(
+          iexecDatasetProvider,
+          { pushDatasetSecret: false },
         );
 
+        // tee fail without secret
         await expect(
           iexecDatasetConsumer.order
             .createRequestorder({
@@ -876,6 +867,7 @@ describe('order', () => {
         const { iexec } = await getTestConfig(testChain)();
         const datasetorder = await deployAndGetDatasetorder(iexec, {
           tag: ['tee'],
+          pushDatasetSecret: false,
         });
         const datasetAddress = datasetorder.dataset;
         await expect(
@@ -1694,42 +1686,21 @@ describe('order', () => {
       const requestorderTagTeeGpu = await iexecRequester.order.signRequestorder(
         {
           ...requestorderTemplate,
-          tag: ['tee', 'tdx', 'gpu'],
+          tag: ['gpu'],
         },
         { preflightCheck: false },
       );
-      const workerpoolorderTagGpu =
+      const workerpoolorderTagNonGpu =
         await iexecPoolManager.order.signWorkerpoolorder({
           ...workerpoolorderTemplate,
-          tag: ['gpu'],
-        });
-      const workerpoolorderTagTee =
-        await iexecPoolManager.order.signWorkerpoolorder({
-          ...workerpoolorderTemplate,
-          tag: ['tee', 'tdx'],
         });
       await expect(
         iexecBroker.order.matchOrders(
           {
             apporder: apporderTemplate,
             datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderTagGpu,
+            workerpoolorder: workerpoolorderTagNonGpu,
             requestorder: requestorderTagTeeGpu,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error('Missing tags [tee,tdx] in workerpoolorder'));
-      const apporderTagGpu = await iexecAppProvider.order.signApporder({
-        ...apporderTemplate,
-        tag: ['gpu'],
-      });
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTagGpu,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderTagTee,
-            requestorder: requestorderTemplate,
           },
           { preflightCheck: false },
         ),
@@ -1747,31 +1718,12 @@ describe('order', () => {
           {
             apporder: apporderTemplate,
             datasetorder: datasetorderTagTeeGpu,
-            workerpoolorder: workerpoolorderTagTee,
+            workerpoolorder: workerpoolorderTagNonGpu,
             requestorder: requestorderTemplate,
           },
           { preflightCheck: false },
         ),
       ).rejects.toThrow(Error('Missing tags [gpu] in workerpoolorder'));
-      // app tag check
-      const requestorderTagTee = await iexecRequester.order.signRequestorder(
-        {
-          ...requestorderTemplate,
-          tag: ['tee', 'tdx'],
-        },
-        { preflightCheck: false },
-      );
-      await expect(
-        iexecBroker.order.matchOrders(
-          {
-            apporder: apporderTemplate,
-            datasetorder: datasetorderTemplate,
-            workerpoolorder: workerpoolorderTagTee,
-            requestorder: requestorderTagTee,
-          },
-          { preflightCheck: false },
-        ),
-      ).rejects.toThrow(Error('Missing tag [tee] in apporder'));
       // price check
       const apporderTooExpensive = await iexecAppProvider.order.signApporder({
         ...apporderTemplate,
@@ -2057,26 +2009,12 @@ describe('order', () => {
       const { iexec: iexecRequester } = await getTestConfig(testChain)();
       const { iexec: iexecResourcesProvider } =
         await getTestConfig(testChain)();
-
-      const apporder = await deployAndGetApporder(iexecResourcesProvider);
-      const datasetorder = await deployAndGetDatasetorder(
-        iexecResourcesProvider,
-      );
-      const workerpoolorder = await deployAndGetWorkerpoolorder(
-        iexecResourcesProvider,
-      );
-      const requestorder = await getMatchableRequestorder(iexecRequester, {
-        apporder,
-        datasetorder,
-        workerpoolorder,
-      });
-
       const teeApporder = await deployAndGetApporder(iexecResourcesProvider, {
         tag: ['tee', 'tdx'],
       });
       const teeDatasetorder = await deployAndGetDatasetorder(
         iexecResourcesProvider,
-        { tag: ['tee'] },
+        { tag: ['tee'], pushDatasetSecret: false },
       );
       const teeWorkerpoolorder = await deployAndGetWorkerpoolorder(
         iexecResourcesProvider,
@@ -2084,17 +2022,6 @@ describe('order', () => {
           tag: ['tee', 'tdx'],
         },
       );
-      const res = await iexecRequester.order.matchOrders({
-        apporder,
-        datasetorder,
-        workerpoolorder,
-        requestorder,
-      });
-      expect(res.txHash).toBeTxHash();
-      expect(res.volume).toBeInstanceOf(BN);
-      expect(res.volume.eq(new BN(1))).toBe(true);
-      expect(res.dealid).toBeTxHash();
-
       // trigger dataset check
       await expect(
         iexecRequester.order.matchOrders({
@@ -2123,10 +2050,6 @@ describe('order', () => {
         {
           tag: ['tee', 'gramine'],
         },
-      );
-      await iexecResourcesProvider.dataset.pushDatasetSecret(
-        datasetorder.dataset,
-        'foo',
       );
       const workerpoolorder = await deployAndGetWorkerpoolorder(
         iexecResourcesProvider,
@@ -2160,12 +2083,6 @@ describe('order', () => {
       });
       const datasetorder = await deployAndGetDatasetorder(
         iexecResourcesProvider,
-        {},
-      );
-      await iexecResourcesProvider.dataset.pushDatasetSecret(
-        datasetorder.dataset,
-        'foo',
-        { teeFramework: TEE_FRAMEWORKS.TDX },
       );
       const workerpoolorder = await deployAndGetWorkerpoolorder(
         iexecResourcesProvider,
@@ -2192,6 +2109,48 @@ describe('order', () => {
           expect(res.volume.eq(new BN(1))).toBe(true);
           expect(res.dealid).toBeTxHash();
         });
+    });
+
+    test('default tag (no tag provided) produces a TDX deal', async () => {
+      const { iexec: iexecRequester, wallet: requesterWallet } =
+        await getTestConfig(testChain)();
+      const { iexec: iexecResourcesProvider, wallet: poolManagerWallet } =
+        await getTestConfig(testChain)();
+
+      await setNRlcBalance(testChain)(requesterWallet.address, 10n * ONE_RLC);
+      await setNRlcBalance(testChain)(poolManagerWallet.address, 10n * ONE_RLC);
+
+      // no tag passed — all orders default to TDX_DEFAULT_TAG
+      const apporder = await deployAndGetApporder(iexecResourcesProvider);
+      const datasetorder = await deployAndGetDatasetorder(
+        iexecResourcesProvider,
+      );
+      const workerpoolorder = await deployAndGetWorkerpoolorder(
+        iexecResourcesProvider,
+      );
+      const requestorder = await getMatchableRequestorder(iexecRequester, {
+        apporder,
+        datasetorder,
+        workerpoolorder,
+      });
+
+      expect(apporder.tag).toBe(TDX_DEFAULT_TAG);
+      expect(datasetorder.tag).toBe(TDX_DEFAULT_TAG);
+      expect(workerpoolorder.tag).toBe(TDX_DEFAULT_TAG);
+      expect(requestorder.tag).toBe(TDX_DEFAULT_TAG);
+
+      const { dealid } = await iexecRequester.order.matchOrders(
+        {
+          apporder,
+          datasetorder,
+          workerpoolorder,
+          requestorder,
+        },
+        { preflightCheck: false },
+      );
+
+      const deal = await iexecRequester.deal.show(dealid);
+      expect(deal.tag).toEqual(encodeTag(['tee', 'tdx']));
     });
   });
 });

--- a/test/lib/lib-test-utils.js
+++ b/test/lib/lib-test-utils.js
@@ -81,9 +81,13 @@ export const deployAndGetDatasetorder = async (
     workerpoolrestrict,
     requesterrestrict,
     tag,
+    pushDatasetSecret = true,
   } = {},
 ) => {
   const datasetDeployRes = await deployRandomDataset(iexec);
+  if (pushDatasetSecret) {
+    await iexec.dataset.pushDatasetSecret(datasetDeployRes.address, 'foo');
+  }
   const dataset = datasetDeployRes.address;
   return iexec.order
     .createDatasetorder({


### PR DESCRIPTION
All order creation functions (createApporder, createDatasetorder, createWorkerpoolorder, createRequestorder) and CLI commands (app run, app request-execution) now default to tag ['tee', 'tdx'] instead of the standard (no-TEE) empty tag.

Introduces TDX_DEFAULT_TAG constant (0x...0009) and updates iexec.json order templates accordingly.

Standard orders remain possible via explicit tag override (tag: []).